### PR TITLE
fix: consolidate duplicate scripts

### DIFF
--- a/LiftTrackerAI/package.json
+++ b/LiftTrackerAI/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "scrape:exercises": "node scripts/scrape-and-rewrite.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -102,10 +103,4 @@
   "optionalDependencies": {
     "bufferutil": "^4.0.8"
   }
-}
-"scripts": {
-  "scrape:exercises": "node scripts/scrape-and-rewrite.mjs",
-  "dev": "NODE_ENV=development tsx server/index.ts",
-  "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-  "start": "NODE_ENV=production node dist/index.js"
 }


### PR DESCRIPTION
## Summary
- merge scrape:exercises into main scripts
- drop extra scripts block from package.json

## Testing
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_68a3ec0802788325a59d0e248eae83b4