### PR TITLE
Fix invalid package.json JSON

### DIFF
--- a/LiftTrackerAI/package.json
+++ b/LiftTrackerAI/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "scrape:exercises": "node scripts/scrape-and-rewrite.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -102,10 +103,4 @@
   "optionalDependencies": {
     "bufferutil": "^4.0.8"
   }
-}
-"scripts": {
-  "scrape:exercises": "node scripts/scrape-and-rewrite.mjs",
-  "dev": "NODE_ENV=development tsx server/index.ts",
-  "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-  "start": "NODE_ENV=production node dist/index.js"
 }


### PR DESCRIPTION
## Summary
- remove duplicate scripts block in package.json
- merge scrape:exercises script with existing scripts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: Cannot find type definition file for 'node', 'vite/client')

------
https://chatgpt.com/codex/tasks/task_e_68a3f175f91c832589921f8ebd20b6b4