### PR TITLE
Add test script to package.json

### DIFF
--- a/LiftTrackerAI/package.json
+++ b/LiftTrackerAI/package.json
@@ -8,6 +8,7 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
+    "test": "vitest",
     "db:push": "drizzle-kit push",
     "scrape:exercises": "node scripts/scrape-and-rewrite.mjs"
   },


### PR DESCRIPTION
## Summary
- add npm `test` script using vitest

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a417ea8d148325a2acb6e399c91d7d