### PR TITLE
Fix optional value handling and cleanup package.json

### DIFF
--- a/LiftTrackerAI/package.json
+++ b/LiftTrackerAI/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "scrape:exercises": "node scripts/scrape-and-rewrite.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -102,10 +103,4 @@
   "optionalDependencies": {
     "bufferutil": "^4.0.8"
   }
-}
-"scripts": {
-  "scrape:exercises": "node scripts/scrape-and-rewrite.mjs",
-  "dev": "NODE_ENV=development tsx server/index.ts",
-  "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-  "start": "NODE_ENV=production node dist/index.js"
 }

--- a/LiftTrackerAI/server/storage.ts
+++ b/LiftTrackerAI/server/storage.ts
@@ -202,12 +202,12 @@ export class MemStorage implements IStorage {
 
   async createWorkoutPlan(insertPlan: InsertWorkoutPlan): Promise<WorkoutPlan> {
     const id = randomUUID();
-    const plan: WorkoutPlan = { 
-      ...insertPlan, 
+    const plan: WorkoutPlan = {
+      ...insertPlan,
       id,
-      userId: insertPlan.userId || null,
-      description: insertPlan.description || null,
-      isTemplate: insertPlan.isTemplate || null
+      userId: insertPlan.userId ?? null,
+      description: insertPlan.description ?? null,
+      isTemplate: insertPlan.isTemplate ?? false
     };
     this.workoutPlans.set(id, plan);
     return plan;
@@ -297,15 +297,15 @@ export class MemStorage implements IStorage {
 
   async createWorkoutSession(insertSession: InsertWorkoutSession): Promise<WorkoutSession> {
     const id = randomUUID();
-    const session: WorkoutSession = { 
-      ...insertSession, 
+    const session: WorkoutSession = {
+      ...insertSession,
       id,
-      workoutPlanId: insertSession.workoutPlanId || null,
-      completedAt: insertSession.completedAt || null,
-      duration: insertSession.duration || null,
-      totalVolume: insertSession.totalVolume || null,
-      notes: insertSession.notes || null,
-      rating: insertSession.rating || null
+      workoutPlanId: insertSession.workoutPlanId ?? null,
+      completedAt: insertSession.completedAt ?? null,
+      duration: insertSession.duration ?? null,
+      totalVolume: insertSession.totalVolume ?? null,
+      notes: insertSession.notes ?? null,
+      rating: insertSession.rating ?? null
     };
     this.workoutSessions.set(id, session);
     return session;
@@ -338,11 +338,11 @@ export class MemStorage implements IStorage {
 
   async createWorkoutSet(insertSet: InsertWorkoutSet): Promise<WorkoutSet> {
     const id = randomUUID();
-    const set: WorkoutSet = { 
-      ...insertSet, 
+    const set: WorkoutSet = {
+      ...insertSet,
       id,
-      weight: insertSet.weight || null,
-      restTime: insertSet.restTime || null
+      weight: insertSet.weight ?? null,
+      restTime: insertSet.restTime ?? null
     };
     this.workoutSets.set(id, set);
     return set;


### PR DESCRIPTION
## Summary
- preserve boolean and numeric values when creating plans, sessions and sets by using nullish coalescing
- merge duplicate script entries to produce valid package.json

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_689e466482748325ae382d62f26e5c39