### PR TITLE
Avoid crashing on logged server errors

### DIFF
--- a/LiftTrackerAI/server/index.ts
+++ b/LiftTrackerAI/server/index.ts
@@ -39,12 +39,13 @@ app.use((req, res, next) => {
 (async () => {
   const server = await registerRoutes(app);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+  app.use((err: any, _req: Request, res: Response, next: NextFunction) => {
     const status = err.status || err.statusCode || 500;
     const message = err.message || "Internal Server Error";
 
+    console.error(err);
     res.status(status).json({ message });
-    throw err;
+    next(err);
   });
 
   // importantly only setup vite in development and after


### PR DESCRIPTION
## Summary
- log errors from the global Express handler instead of throwing
- continue processing middleware with `next(err)` after responding

## Testing
- `npm test` *(fails: Invalid package.json: JSON.parse Invalid package.json: JSONParseError)*

------
https://chatgpt.com/codex/tasks/task_e_689e47a01e208325918cc5a563a2c3a4