### PR TITLE
fix: preserve boolean value when creating workout plan

### DIFF
--- a/LiftTrackerAI/server/storage.test.ts
+++ b/LiftTrackerAI/server/storage.test.ts
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { MemStorage } from './storage';
+import type { InsertWorkoutPlan } from '../shared/schema';
+
+test('createWorkoutPlan retains false isTemplate value', async () => {
+  const storage = new MemStorage();
+  const data: InsertWorkoutPlan = {
+    name: 'Test Plan',
+    level: 'beginner',
+    daysPerWeek: 3,
+    exercises: [],
+    isTemplate: false,
+  };
+
+  const plan = await storage.createWorkoutPlan(data);
+  assert.equal(plan.isTemplate, false);
+});

--- a/LiftTrackerAI/server/storage.ts
+++ b/LiftTrackerAI/server/storage.ts
@@ -202,12 +202,12 @@ export class MemStorage implements IStorage {
 
   async createWorkoutPlan(insertPlan: InsertWorkoutPlan): Promise<WorkoutPlan> {
     const id = randomUUID();
-    const plan: WorkoutPlan = { 
-      ...insertPlan, 
+    const plan: WorkoutPlan = {
+      ...insertPlan,
       id,
-      userId: insertPlan.userId || null,
-      description: insertPlan.description || null,
-      isTemplate: insertPlan.isTemplate || null
+      userId: insertPlan.userId ?? null,
+      description: insertPlan.description ?? null,
+      isTemplate: insertPlan.isTemplate ?? false
     };
     this.workoutPlans.set(id, plan);
     return plan;


### PR DESCRIPTION
## Summary
- use nullish coalescing to keep `isTemplate` boolean when creating workout plans
- add regression test for `createWorkoutPlan`

## Testing
- `node --import tsx --test server/storage.test.ts`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a41a35de5c832598493fc73dea9fa8