### PR TITLE
feat: track workout history and past sessions

### DIFF
--- a/LiftTrackerAI/client/public/past-workouts.html
+++ b/LiftTrackerAI/client/public/past-workouts.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Past Workouts</title>
+</head>
+<body>
+  <h1>Past Workouts</h1>
+  <ul id="history-list"></ul>
+  <script src="past-workouts.js"></script>
+</body>
+</html>

--- a/LiftTrackerAI/client/public/past-workouts.js
+++ b/LiftTrackerAI/client/public/past-workouts.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const historyList = document.getElementById('history-list');
+  const storedHistory = localStorage.getItem('workoutHistory');
+
+  if (!storedHistory) {
+    historyList.innerHTML = '<li>No past workouts found.</li>';
+    return;
+  }
+
+  try {
+    const workouts = JSON.parse(storedHistory);
+    if (workouts.length === 0) {
+      historyList.innerHTML = '<li>No past workouts found.</li>';
+      return;
+    }
+
+    workouts.forEach(workout => {
+      const workoutItem = document.createElement('li');
+      workoutItem.innerHTML = `<strong>${workout.date}</strong>`;
+      const exerciseList = document.createElement('ul');
+
+      workout.exercises.forEach(ex => {
+        const exerciseItem = document.createElement('li');
+        const weightText = ex.weight > 0 ? ` with ${ex.weight} lbs` : '';
+        exerciseItem.textContent = `${ex.name} - ${ex.sets}x${ex.reps}${weightText}`;
+        exerciseList.appendChild(exerciseItem);
+      });
+
+      workoutItem.appendChild(exerciseList);
+      historyList.appendChild(workoutItem);
+    });
+  } catch (error) {
+    console.error('Error loading workout history:', error);
+    historyList.innerHTML = '<li>Error loading workout history.</li>';
+  }
+});

--- a/LiftTrackerAI/client/public/workout.js
+++ b/LiftTrackerAI/client/public/workout.js
@@ -1,4 +1,5 @@
 let currentWorkout = [];
+let workoutHistory = [];
 let workoutList;
 
 // Load workout on page load
@@ -48,7 +49,8 @@ function renderWorkoutList() {
     currentWorkout.forEach((exercise, index) => {
         const listItem = document.createElement('li');
         listItem.className = 'exercise-item';
-        listItem.textContent = `${exercise.name} - ${exercise.sets}x${exercise.reps}${exercise.weight > 0 ? ` with ${exercise.weight} lbs` : ''} `;
+        const weightText = exercise.weight > 0 ? ` with ${exercise.weight} lbs` : '';
+        listItem.textContent = `${exercise.name} - ${exercise.sets}x${exercise.reps}${weightText} `;
 
         const deleteBtn = document.createElement('button');
         deleteBtn.textContent = 'X';
@@ -72,27 +74,38 @@ function saveWorkout() {
         alert('No exercises to save!');
         return;
     }
-    
-    // Save the data array, not HTML
-    localStorage.setItem('savedWorkout', JSON.stringify(currentWorkout));
+
+    const workout = {
+        id: Date.now(),
+        date: new Date().toISOString().split('T')[0],
+        exercises: currentWorkout,
+    };
+
+    workoutHistory = [...workoutHistory, workout];
+    localStorage.setItem('workoutHistory', JSON.stringify(workoutHistory));
     alert('Workout saved successfully!');
 }
 
 // Load workout
 function loadWorkout() {
-    const savedData = localStorage.getItem('savedWorkout');
-    
-    if (savedData) {
+    const storedHistory = localStorage.getItem('workoutHistory');
+
+    if (storedHistory) {
         try {
-            currentWorkout = JSON.parse(savedData);
-            renderWorkoutList();
-            alert('Workout loaded successfully!');
+            workoutHistory = JSON.parse(storedHistory);
+            if (workoutHistory.length > 0) {
+                currentWorkout = workoutHistory[workoutHistory.length - 1].exercises;
+                renderWorkoutList();
+                alert('Last workout loaded successfully!');
+            } else {
+                alert('No saved workouts found.');
+            }
         } catch (error) {
-            console.error('Error loading workout:', error);
-            alert('Error loading saved workout. Data might be corrupted.');
+            console.error('Error loading workout history:', error);
+            alert('Error loading workout history. Data might be corrupted.');
         }
     } else {
-        alert('No saved workout found.');
+        alert('No saved workouts found.');
     }
 }
 
@@ -103,7 +116,6 @@ function clearWorkout() {
         if (workoutList) {
             workoutList.innerHTML = '';
         }
-        localStorage.removeItem('savedWorkout');
     }
 }
 


### PR DESCRIPTION
## Summary
- store workouts in history instead of single save
- add simple past workouts page to review saved sessions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5220860fc83258670ddf8b5929ee1