### PR TITLE
Use CSS class for exercise form visibility

### DIFF
--- a/LiftTrackerAI/client/public/style.css
+++ b/LiftTrackerAI/client/public/style.css
@@ -1,0 +1,3 @@
+.hidden {
+    display: none;
+}

--- a/LiftTrackerAI/client/public/workout.js
+++ b/LiftTrackerAI/client/public/workout.js
@@ -37,9 +37,12 @@ function addExercise() {
         // Update the display
         renderWorkoutList();
 
-        // Reset form
-        document.getElementById('exercise-form').reset();
-        toggleExerciseForm();
+        // Reset form and hide it
+        const exerciseForm = document.getElementById('exercise-form');
+        if (exerciseForm) {
+            exerciseForm.reset();
+            hideExerciseForm();
+        }
     } else {
         alert('Please enter valid numbers greater than 0 for sets and reps');
     }
@@ -127,7 +130,27 @@ function clearWorkout() {
 function toggleExerciseForm() {
     const form = document.getElementById('exercise-form');
     if (form) {
-        form.classList.toggle('hidden');
+        if (form.classList.contains('hidden')) {
+            form.classList.remove('hidden');
+        } else {
+            form.classList.add('hidden');
+        }
+    }
+}
+
+// Hide the exercise form by adding the "hidden" class
+function hideExerciseForm() {
+    const form = document.getElementById('exercise-form');
+    if (form) {
+        form.classList.add('hidden');
+    }
+}
+
+// Show the exercise form by removing the "hidden" class
+function showExerciseForm() {
+    const form = document.getElementById('exercise-form');
+    if (form) {
+        form.classList.remove('hidden');
     }
 }
 


### PR DESCRIPTION
## Summary
- define `.hidden` CSS class to hide elements
- toggle exercise form visibility by adding or removing the `hidden` class instead of inline styles
- provide helpers for explicitly showing or hiding the form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a525c7b5348325ac34e0c463b7dc9c