### PR TITLE
feat: add rest timer with customization

### DIFF
--- a/LiftTrackerAI/client/src/components/workout/timer.tsx
+++ b/LiftTrackerAI/client/src/components/workout/timer.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Play, Pause, RotateCcw } from "lucide-react";
 import { formatDuration } from "@/lib/workout-utils";
 
@@ -8,118 +9,98 @@ interface TimerProps {
   initialTime?: number;
   isRestTimer?: boolean;
   onComplete?: () => void;
+  previousSet?: { weight?: number | null; reps?: number | null } | null;
 }
 
-export default function Timer({ initialTime = 0, isRestTimer = false, onComplete }: TimerProps) {
+export default function Timer({
+  initialTime = 0,
+  isRestTimer = false,
+  onComplete,
+  previousSet,
+}: TimerProps) {
   const [time, setTime] = useState(initialTime);
-  const [isRunning, setIsRunning] = useState(false);
-  const [targetTime, setTargetTime] = useState(isRestTimer ? 120 : 0); // 2 minutes default rest
+  const [isRunning, setIsRunning] = useState(isRestTimer);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    let interval: NodeJS.Timeout;
+    setTime(initialTime);
+    setIsRunning(isRestTimer);
+  }, [initialTime, isRestTimer]);
 
+  useEffect(() => {
+    let interval: NodeJS.Timeout | undefined;
     if (isRunning) {
       interval = setInterval(() => {
-        setTime(prevTime => {
-          const newTime = isRestTimer ? prevTime - 1 : prevTime + 1;
-          
-          // Rest timer completed
-          if (isRestTimer && newTime <= 0) {
+        setTime((prev) => {
+          const next = isRestTimer ? prev - 1 : prev + 1;
+          if (isRestTimer && next <= 0) {
             setIsRunning(false);
             onComplete?.();
             return 0;
           }
-          
-          return newTime;
+          return next;
         });
       }, 1000);
     }
-
     return () => {
-      if (interval) {
-        clearInterval(interval);
-      }
+      if (interval) clearInterval(interval);
     };
   }, [isRunning, isRestTimer, onComplete]);
 
-  const handleStartPause = () => {
-    setIsRunning(!isRunning);
+  const adjustTime = (delta: number) => {
+    setTime((prev) => Math.max(0, prev + delta));
   };
 
-  const handleReset = () => {
-    setIsRunning(false);
-    setTime(isRestTimer ? targetTime : 0);
+  const resetTime = () => {
+    setTime(initialTime);
+    setIsRunning(isRestTimer);
   };
-
-  const handleRestTimeSet = (seconds: number) => {
-    setTargetTime(seconds);
-    setTime(seconds);
-    setIsRunning(false);
-  };
-
-  const progressPercentage = isRestTimer && targetTime > 0 
-    ? ((targetTime - time) / targetTime) * 100 
-    : 0;
 
   return (
-    <Card className={`w-full max-w-sm mx-auto ${
-      isRestTimer ? 'bg-orange-50 border-orange-200 dark:bg-orange-900 dark:border-orange-800' : ''
-    }`}>
-      <CardContent className="p-6 text-center">
-        <div className={`text-4xl font-bold mb-4 ${
-          isRestTimer ? 'text-orange-800 dark:text-orange-200' : 'text-gray-900 dark:text-white'
-        }`}>
-          {formatDuration(Math.abs(time))}
-        </div>
-
-        {isRestTimer && (
-          <div className="mb-4">
-            <div className="w-full bg-orange-200 dark:bg-orange-800 rounded-full h-2 mb-2">
-              <div 
-                className="bg-orange-600 h-2 rounded-full transition-all duration-1000"
-                style={{ width: `${progressPercentage}%` }}
-              ></div>
-            </div>
-            <p className="text-sm text-orange-700 dark:text-orange-300">Rest Time</p>
+    <>
+      <Card className="w-full max-w-sm mx-auto">
+        <CardContent className="p-4">
+          <div className="flex items-center justify-between">
+            {previousSet && (
+              <span className="text-sm text-gray-600">
+                Last: {previousSet.weight ?? "-"}
+                {previousSet.weight ? " lbs" : ""} × {previousSet.reps ?? "-"}
+              </span>
+            )}
+            <button
+              onClick={() => setOpen(true)}
+              className="text-xl font-bold font-mono"
+            >
+              {formatDuration(Math.abs(time))}
+            </button>
           </div>
-        )}
+        </CardContent>
+      </Card>
 
-        <div className="flex space-x-2 mb-4">
-          <Button
-            onClick={handleStartPause}
-            className={`flex-1 ${
-              isRestTimer 
-                ? 'bg-orange-600 hover:bg-orange-700 text-white' 
-                : 'bg-primary-600 hover:bg-primary-700'
-            }`}
-          >
-            {isRunning ? <Pause className="h-4 w-4 mr-2" /> : <Play className="h-4 w-4 mr-2" />}
-            {isRunning ? "Pause" : "Start"}
-          </Button>
-          
-          <Button onClick={handleReset} variant="outline" size="icon">
-            <RotateCcw className="h-4 w-4" />
-          </Button>
-        </div>
-
-        {isRestTimer && (
-          <div className="flex space-x-1">
-            {[60, 90, 120, 180, 300].map((seconds) => (
-              <Button
-                key={seconds}
-                onClick={() => handleRestTimeSet(seconds)}
-                variant="outline"
-                size="sm"
-                className={`text-xs ${
-                  targetTime === seconds ? 'bg-orange-100 border-orange-300 dark:bg-orange-800' : ''
-                }`}
-              >
-                {seconds < 60 ? `${seconds}s` : `${Math.floor(seconds / 60)}m`}
-              </Button>
-            ))}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="flex flex-col items-center space-y-4">
+          <div className="text-6xl font-bold font-mono">
+            {formatDuration(Math.abs(time))}
           </div>
-        )}
-      </CardContent>
-    </Card>
+          <div className="flex space-x-4">
+            <Button onClick={() => adjustTime(-30)} variant="outline">
+              -30s
+            </Button>
+            <Button onClick={() => adjustTime(30)} variant="outline">
+              +30s
+            </Button>
+          </div>
+          <div className="flex space-x-2">
+            <Button onClick={() => setIsRunning((r) => !r)}>
+              {isRunning ? <Pause className="h-4 w-4 mr-2" /> : <Play className="h-4 w-4 mr-2" />}
+              {isRunning ? "Pause" : "Start"}
+            </Button>
+            <Button onClick={resetTime} variant="outline">
+              <RotateCcw className="h-4 w-4 mr-2" /> Reset
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/LiftTrackerAI/client/src/contexts/settings-context.tsx
+++ b/LiftTrackerAI/client/src/contexts/settings-context.tsx
@@ -6,11 +6,13 @@ export interface SettingsContextType {
   darkMode: boolean;
   notifications: boolean;
   autoRest: boolean;
+  restInterval: number;
   setLanguage: (language: string) => void;
   setWeightUnit: (unit: 'lbs' | 'kg') => void;
   setDarkMode: (enabled: boolean) => void;
   setNotifications: (enabled: boolean) => void;
   setAutoRest: (enabled: boolean) => void;
+  setRestInterval: (seconds: number) => void;
   convertWeight: (weight: number, fromUnit?: string, toUnit?: string) => number;
   formatWeight: (weight: number) => string;
 }
@@ -42,8 +44,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
   const [notifications, setNotificationsState] = useState(() => 
     localStorage.getItem('fitness-app-notifications') !== 'false'
   );
-  const [autoRest, setAutoRestState] = useState(() => 
+  const [autoRest, setAutoRestState] = useState(() =>
     localStorage.getItem('fitness-app-auto-rest') !== 'false'
+  );
+  const [restInterval, setRestIntervalState] = useState(() =>
+    parseInt(localStorage.getItem('fitness-app-rest-interval') || '90', 10)
   );
 
   // Apply dark mode on initial load
@@ -77,6 +82,11 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
     localStorage.setItem('fitness-app-auto-rest', enabled.toString());
   };
 
+  const setRestInterval = (seconds: number) => {
+    setRestIntervalState(seconds);
+    localStorage.setItem('fitness-app-rest-interval', seconds.toString());
+  };
+
   const convertWeight = (weight: number, fromUnit?: string, toUnit?: string): number => {
     const from = fromUnit || weightUnit;
     const to = toUnit || weightUnit;
@@ -97,11 +107,13 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
     darkMode,
     notifications,
     autoRest,
+    restInterval,
     setLanguage,
     setWeightUnit,
     setDarkMode,
     setNotifications,
     setAutoRest,
+    setRestInterval,
     convertWeight,
     formatWeight,
   };

--- a/LiftTrackerAI/client/src/pages/active-workout.tsx
+++ b/LiftTrackerAI/client/src/pages/active-workout.tsx
@@ -20,6 +20,8 @@ export default function ActiveWorkout() {
   const [workoutTime, setWorkoutTime] = useState(0);
   const [isWorkoutRunning, setIsWorkoutRunning] = useState(false);
   const [showRestTimer, setShowRestTimer] = useState(false);
+  const [restDuration, setRestDuration] = useState(0);
+  const [lastSetInfo, setLastSetInfo] = useState<WorkoutSet | null>(null);
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
@@ -156,7 +158,9 @@ export default function ActiveWorkout() {
     }
   };
 
-  const handleSetLogged = () => {
+  const handleSetLogged = ({ restTime, previousSet }: { restTime: number; previousSet?: WorkoutSet | null }) => {
+    setRestDuration(restTime);
+    setLastSetInfo(previousSet ?? null);
     setShowRestTimer(true);
     queryClient.invalidateQueries({ queryKey: ["/api/workout-sets"] });
   };
@@ -284,14 +288,16 @@ export default function ActiveWorkout() {
           {/* Exercise Logger */}
           <div>
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Log Exercise</h3>
-            {showRestTimer ? (
-              <Timer
-                initialTime={120}
-                isRestTimer={true}
-                onComplete={handleRestComplete}
-              />
-            ) : (
-              <ExerciseLogger sessionId={activeSession.id} onSetLogged={handleSetLogged} />
+            <ExerciseLogger sessionId={activeSession.id} onSetLogged={handleSetLogged} />
+            {showRestTimer && (
+              <div className="mt-4">
+                <Timer
+                  initialTime={restDuration}
+                  isRestTimer={true}
+                  onComplete={handleRestComplete}
+                  previousSet={lastSetInfo}
+                />
+              </div>
             )}
           </div>
 

--- a/LiftTrackerAI/client/src/pages/settings.tsx
+++ b/LiftTrackerAI/client/src/pages/settings.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
 import { Globe, Weight, Moon, Sun, Bell, Smartphone, SettingsIcon } from "lucide-react";
@@ -27,6 +28,7 @@ export default function Settings() {
   const [darkMode, setDarkMode] = useState(localStorage.getItem('fitness-app-theme') === 'dark');
   const [notifications, setNotifications] = useState(localStorage.getItem('fitness-app-notifications') !== 'false');
   const [autoRest, setAutoRest] = useState(localStorage.getItem('fitness-app-auto-rest') !== 'false');
+  const [restInterval, setRestInterval] = useState(parseInt(localStorage.getItem('fitness-app-rest-interval') || '90', 10));
   const { toast } = useToast();
 
   const handleLanguageChange = (newLanguage: string) => {
@@ -72,6 +74,16 @@ export default function Settings() {
     toast({
       title: "Auto-rest updated",
       description: `Auto-rest timer ${enabled ? 'enabled' : 'disabled'}`,
+    });
+  };
+
+  const handleRestIntervalChange = (value: string) => {
+    const seconds = parseInt(value, 10) || 0;
+    setRestInterval(seconds);
+    localStorage.setItem('fitness-app-rest-interval', seconds.toString());
+    toast({
+      title: "Rest timer updated",
+      description: `Default rest time set to ${seconds}s`,
     });
   };
 
@@ -255,6 +267,22 @@ export default function Settings() {
                 id="auto-rest"
                 checked={autoRest}
                 onCheckedChange={handleAutoRestToggle}
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <div>
+                <Label htmlFor="rest-interval">Default Rest Time (s)</Label>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Used when exercise rest time isn't specified
+                </p>
+              </div>
+              <Input
+                id="rest-interval"
+                type="number"
+                value={restInterval}
+                onChange={(e) => handleRestIntervalChange(e.target.value)}
+                className="w-24"
               />
             </div>
           </CardContent>


### PR DESCRIPTION
## Summary
- add configurable rest interval to settings and context
- allow exercises to specify rest timer and display last set info
- introduce rest timer with fullscreen adjust controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a52a6724248325ab97d6342d58f091