### PR TITLE
feat: use svg icons for PWA

### DIFF
--- a/LiftTrackerAI/client/index.html
+++ b/LiftTrackerAI/client/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <link rel="manifest" href="/manifest.json" />
   </head>
   <body>
     <div id="root"></div>

--- a/LiftTrackerAI/client/public/icon-192.svg
+++ b/LiftTrackerAI/client/public/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" width="192" height="192">
+  <rect width="192" height="192" rx="32" fill="#4caf50"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="96" fill="#ffffff">L</text>
+</svg>

--- a/LiftTrackerAI/client/public/icon-512.svg
+++ b/LiftTrackerAI/client/public/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="64" fill="#4caf50"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="256" fill="#ffffff">L</text>
+</svg>

--- a/LiftTrackerAI/client/public/manifest.json
+++ b/LiftTrackerAI/client/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "LiftTrackerAI",
+  "short_name": "LiftTracker",
+  "icons": [
+    {
+      "src": "icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#4caf50"
+}


### PR DESCRIPTION
## Summary
- replace binary PNG icons with lightweight SVG versions
- reference new icons in a fresh web manifest and link it in the client

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a52e95e99483258eab69bb83f618d2