### PR TITLE
Enable PWA support with service worker

### DIFF
--- a/LiftTrackerAI/client/index.html
+++ b/LiftTrackerAI/client/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <meta name="theme-color" content="#4caf50" />
     <link rel="manifest" href="/manifest.json" />
   </head>
   <body>

--- a/LiftTrackerAI/client/public/manifest.json
+++ b/LiftTrackerAI/client/public/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "LiftTrackerAI",
   "short_name": "LiftTracker",
+  "description": "Track workouts offline with AI assistance",
   "icons": [
     {
       "src": "icon-192.svg",
@@ -14,6 +15,7 @@
     }
   ],
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#4caf50"

--- a/LiftTrackerAI/client/public/service-worker.js
+++ b/LiftTrackerAI/client/public/service-worker.js
@@ -1,0 +1,30 @@
+const CACHE_NAME = 'lifttracker-cache-v1';
+const ASSETS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/icon-192.svg',
+  '/icon-512.svg'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  );
+});

--- a/LiftTrackerAI/client/src/main.tsx
+++ b/LiftTrackerAI/client/src/main.tsx
@@ -3,3 +3,11 @@ import App from "./App";
 import "./index.css";
 
 createRoot(document.getElementById("root")!).render(<App />);
+
+if ("serviceWorker" in navigator && import.meta.env.PROD) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker
+      .register("/service-worker.js")
+      .catch((err) => console.error("Service worker registration failed:", err));
+  });
+}


### PR DESCRIPTION
## Summary
- expand web app manifest and theme colors for installable PWA
- add service worker caching static assets for offline support
- register service worker during app startup

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a52fd629008325bfc662f11e87ff18