### PR TITLE
feat(theme): add multi-theme system with runtime switching

### DIFF
--- a/LiftTrackerAI/client/src/App.tsx
+++ b/LiftTrackerAI/client/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "@/pages/not-found";
 import { SettingsProvider } from "@/contexts/settings-context";
 import MobileNavigation from "@/components/layout/mobile-navigation";
 import DesktopSidebar from "@/components/layout/desktop-sidebar";
+import ThemeProvider from "@/components/theme/ThemeProvider";
 
 function Router() {
   return (
@@ -38,18 +39,20 @@ function Router() {
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <SettingsProvider>
-        <TooltipProvider>
-          <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-            <DesktopSidebar />
-            <div className="lg:ml-64 pb-16 lg:pb-0">
-              <Router />
+      <ThemeProvider>
+        <SettingsProvider>
+          <TooltipProvider>
+            <div className="min-h-screen bg-bg text-fg">
+              <DesktopSidebar />
+              <div className="lg:ml-64 pb-16 lg:pb-0">
+                <Router />
+              </div>
+              <MobileNavigation />
             </div>
-            <MobileNavigation />
-          </div>
-          <Toaster />
-        </TooltipProvider>
-      </SettingsProvider>
+            <Toaster />
+          </TooltipProvider>
+        </SettingsProvider>
+      </ThemeProvider>
     </QueryClientProvider>
   );
 }

--- a/LiftTrackerAI/client/src/components/theme/ThemeProvider.tsx
+++ b/LiftTrackerAI/client/src/components/theme/ThemeProvider.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { createContext, useContext } from "react";
+import { useTheme } from "@/hooks/useTheme";
+
+type Ctx = ReturnType<typeof useTheme>;
+const ThemeCtx = createContext<Ctx | null>(null);
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const ctx = useTheme();
+  return <ThemeCtx.Provider value={ctx}>{children}</ThemeCtx.Provider>;
+}
+
+export function useThemeCtx() {
+  const ctx = useContext(ThemeCtx);
+  if (!ctx) throw new Error("useThemeCtx must be used within ThemeProvider");
+  return ctx;
+}

--- a/LiftTrackerAI/client/src/components/theme/ThemeSelector.tsx
+++ b/LiftTrackerAI/client/src/components/theme/ThemeSelector.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { THEMES, type ThemeId } from "@/lib/theme";
+import { useThemeCtx } from "./ThemeProvider";
+
+export default function ThemeSelector() {
+  const { theme, setTheme } = useThemeCtx();
+
+  return (
+    <div className="space-y-3">
+      <div className="font-semibold">App Theme</div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {THEMES.map(t => (
+          <button
+            key={t.id}
+            onClick={() => setTheme(t.id as ThemeId)}
+            className={`rounded-2xl p-4 border transition 
+              ${theme===t.id ? "border-primary ring-2 ring-primary" : "border-card hover:border-primary/50"}`}
+          >
+            <div className="text-sm">{t.name}</div>
+            <div className="mt-2 h-8 rounded-lg"
+                 style={{
+                   background: "linear-gradient(90deg, var(--color-primary), var(--color-secondary))"
+                 }}
+            />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/LiftTrackerAI/client/src/hooks/useTheme.ts
+++ b/LiftTrackerAI/client/src/hooks/useTheme.ts
@@ -1,0 +1,24 @@
+"use client";
+import { useEffect, useState } from "react";
+import { DEFAULT_THEME, THEME_STORAGE_KEY, type ThemeId } from "@/lib/theme";
+
+export function useTheme() {
+  const [theme, setThemeState] = useState<ThemeId>(DEFAULT_THEME);
+
+  useEffect(() => {
+    const saved = (typeof window !== "undefined" && localStorage.getItem(THEME_STORAGE_KEY)) as ThemeId | null;
+    const t = saved ?? DEFAULT_THEME;
+    setThemeState(t);
+    document.documentElement.setAttribute("data-theme", t === "default" ? "" : t);
+  }, []);
+
+  function setTheme(t: ThemeId) {
+    setThemeState(t);
+    if (typeof window !== "undefined") {
+      localStorage.setItem(THEME_STORAGE_KEY, t);
+    }
+    document.documentElement.setAttribute("data-theme", t === "default" ? "" : t);
+  }
+
+  return { theme, setTheme };
+}

--- a/LiftTrackerAI/client/src/index.css
+++ b/LiftTrackerAI/client/src/index.css
@@ -1,90 +1,61 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+@import "../../styles/themes.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
+/* smooth transitions when switching */
+:root, [data-theme] {
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
 :root {
-  --background: hsl(0 0% 100%);
-  --foreground: hsl(210 25% 7.8431%);
-  --card: hsl(180 6.6667% 97.0588%);
-  --card-foreground: hsl(210 25% 7.8431%);
-  --popover: hsl(0 0% 100%);
-  --popover-foreground: hsl(210 25% 7.8431%);
-  --primary: hsl(217.2 91.2% 59.8%);
-  --primary-foreground: hsl(0 0% 100%);
-  --primary-50: hsl(214.3 100% 97.1%);
-  --primary-600: hsl(220.9 84.2% 65.1%);
-  --primary-700: hsl(224.3 76.3% 48%);
-  --secondary: hsl(210 25% 7.8431%);
-  --secondary-foreground: hsl(0 0% 100%);
-  --muted: hsl(240 1.9608% 90%);
-  --muted-foreground: hsl(210 25% 7.8431%);
-  --accent: hsl(211.5789 51.3514% 92.7451%);
-  --accent-foreground: hsl(203.8863 88.2845% 53.1373%);
-  --destructive: hsl(356.3033 90.5579% 54.3137%);
-  --destructive-foreground: hsl(0 0% 100%);
-  --border: hsl(201.4286 30.4348% 90.9804%);
-  --input: hsl(200 23.0769% 97.4510%);
-  --ring: hsl(202.8169 89.1213% 53.1373%);
-  --success: hsl(142.1 76.2% 36.3%);
-  --success-50: hsl(138.5 76.5% 96.7%);
-  --success-600: hsl(142.1 70.6% 45.3%);
-  --orange-50: hsl(33.3 100% 96.5%);
-  --orange-600: hsl(20.5 90.2% 48.2%);
-  --yellow-50: hsl(54.5 91.7% 95.3%);
-  --yellow-400: hsl(45 93.4% 47.5%);
-  --gray-50: hsl(210 20% 98%);
-  --gray-100: hsl(220 14.3% 95.9%);
-  --gray-200: hsl(220 13% 91%);
-  --gray-500: hsl(220 8.9% 46.1%);
-  --gray-600: hsl(215 13.8% 34.1%);
-  --gray-700: hsl(215 25% 26.7%);
-  --gray-800: hsl(217.2 32.6% 17.5%);
-  --gray-900: hsl(222.2 84% 4.9%);
+  --background: var(--color-bg);
+  --foreground: var(--color-fg);
+  --card: var(--color-card);
+  --card-foreground: var(--color-fg);
+  --popover: var(--color-card);
+  --popover-foreground: var(--color-fg);
+  --primary: var(--color-primary);
+  --primary-foreground: #ffffff;
+  --primary-50: var(--color-primary);
+  --primary-600: var(--color-primary);
+  --primary-700: var(--color-primary);
+  --secondary: var(--color-secondary);
+  --secondary-foreground: #ffffff;
+  --muted: var(--color-muted);
+  --muted-foreground: var(--color-fg);
+  --accent: var(--color-accent);
+  --accent-foreground: #ffffff;
+  --destructive: var(--color-danger);
+  --destructive-foreground: #ffffff;
+  --border: var(--color-card);
+  --input: var(--color-card);
+  --ring: var(--color-primary);
+  --success: var(--color-success);
+  --success-50: var(--color-success);
+  --success-600: var(--color-success);
+  --orange-50: var(--color-accent);
+  --orange-600: var(--color-accent);
+  --yellow-50: var(--color-warning);
+  --yellow-400: var(--color-warning);
+  --gray-50: var(--color-bg);
+  --gray-100: var(--color-card);
+  --gray-200: var(--color-muted);
+  --gray-500: var(--color-muted);
+  --gray-600: var(--color-muted);
+  --gray-700: var(--color-muted);
+  --gray-800: var(--color-fg);
+  --gray-900: var(--color-fg);
   --font-sans: 'Inter', sans-serif;
   --font-serif: Georgia, serif;
   --font-mono: Menlo, monospace;
   --radius: 0.75rem;
 }
 
-.dark {
-  --background: hsl(0 0% 0%);
-  --foreground: hsl(200 6.6667% 91.1765%);
-  --card: hsl(228 9.8039% 10%);
-  --card-foreground: hsl(0 0% 85.0980%);
-  --popover: hsl(0 0% 0%);
-  --popover-foreground: hsl(200 6.6667% 91.1765%);
-  --primary: hsl(217.2 91.2% 59.8%);
-  --primary-foreground: hsl(0 0% 100%);
-  --primary-50: hsl(224.3 76.3% 8%);
-  --primary-600: hsl(220.9 84.2% 65.1%);
-  --primary-700: hsl(224.3 76.3% 48%);
-  --secondary: hsl(195.0000 15.3846% 94.9020%);
-  --secondary-foreground: hsl(210 25% 7.8431%);
-  --muted: hsl(0 0% 9.4118%);
-  --muted-foreground: hsl(210 3.3898% 46.2745%);
-  --accent: hsl(205.7143 70% 7.8431%);
-  --accent-foreground: hsl(203.7736 87.6033% 52.5490%);
-  --destructive: hsl(356.3033 90.5579% 54.3137%);
-  --destructive-foreground: hsl(0 0% 100%);
-  --border: hsl(210 5.2632% 14.9020%);
-  --input: hsl(207.6923 27.6596% 18.4314%);
-  --ring: hsl(202.8169 89.1213% 53.1373%);
-  --success: hsl(142.1 76.2% 36.3%);
-  --success-50: hsl(138.5 76.5% 6.7%);
-  --success-600: hsl(142.1 70.6% 45.3%);
-  --orange-50: hsl(33.3 100% 6.5%);
-  --orange-600: hsl(20.5 90.2% 48.2%);
-  --yellow-50: hsl(54.5 91.7% 5.3%);
-  --yellow-400: hsl(45 93.4% 47.5%);
-  --gray-50: hsl(222.2 84% 4.9%);
-  --gray-100: hsl(217.2 32.6% 17.5%);
-  --gray-200: hsl(215 25% 26.7%);
-  --gray-500: hsl(220 8.9% 46.1%);
-  --gray-600: hsl(215 13.8% 34.1%);
-  --gray-700: hsl(220 13% 91%);
-  --gray-800: hsl(220 14.3% 95.9%);
-  --gray-900: hsl(210 20% 98%);
+body {
+  background: var(--color-bg);
+  color: var(--color-fg);
 }
 
 @layer base {
@@ -94,77 +65,5 @@
 
   body {
     @apply font-sans antialiased bg-background text-foreground;
-  }
-}
-
-@layer utilities {
-  .text-primary-50 {
-    color: hsl(var(--primary-50));
-  }
-  .bg-primary-50 {
-    background-color: hsl(var(--primary-50));
-  }
-  .text-primary-600 {
-    color: hsl(var(--primary-600));
-  }
-  .bg-primary-600 {
-    background-color: hsl(var(--primary-600));
-  }
-  .bg-primary-700 {
-    background-color: hsl(var(--primary-700));
-  }
-  .hover\:bg-primary-700:hover {
-    background-color: hsl(var(--primary-700));
-  }
-  .text-success-600 {
-    color: hsl(var(--success-600));
-  }
-  .bg-success-50 {
-    background-color: hsl(var(--success-50));
-  }
-  .bg-success-600 {
-    background-color: hsl(var(--success-600));
-  }
-  .text-orange-600 {
-    color: hsl(var(--orange-600));
-  }
-  .bg-orange-50 {
-    background-color: hsl(var(--orange-50));
-  }
-  .text-yellow-400 {
-    color: hsl(var(--yellow-400));
-  }
-  .bg-yellow-50 {
-    background-color: hsl(var(--yellow-50));
-  }
-  .bg-gray-50 {
-    background-color: hsl(var(--gray-50));
-  }
-  .bg-gray-100 {
-    background-color: hsl(var(--gray-100));
-  }
-  .hover\:bg-gray-100:hover {
-    background-color: hsl(var(--gray-100));
-  }
-  .border-gray-100 {
-    border-color: hsl(var(--gray-100));
-  }
-  .border-gray-200 {
-    border-color: hsl(var(--gray-200));
-  }
-  .text-gray-500 {
-    color: hsl(var(--gray-500));
-  }
-  .text-gray-600 {
-    color: hsl(var(--gray-600));
-  }
-  .text-gray-700 {
-    color: hsl(var(--gray-700));
-  }
-  .text-gray-800 {
-    color: hsl(var(--gray-800));
-  }
-  .text-gray-900 {
-    color: hsl(var(--gray-900));
   }
 }

--- a/LiftTrackerAI/client/src/lib/theme.ts
+++ b/LiftTrackerAI/client/src/lib/theme.ts
@@ -1,0 +1,11 @@
+export const THEMES = [
+  { id: "default", name: "Energy (Default)" },
+  { id: "darkpro", name: "Dark Pro" },
+  { id: "sunset",  name: "Sunset Glow" },
+  { id: "minimal", name: "Minimal White" },
+  { id: "arcade",  name: "Retro Arcade" }
+] as const;
+
+export type ThemeId = typeof THEMES[number]["id"];
+export const DEFAULT_THEME: ThemeId = "default";
+export const THEME_STORAGE_KEY = "liftlegends.theme";

--- a/LiftTrackerAI/client/src/pages/settings.tsx
+++ b/LiftTrackerAI/client/src/pages/settings.tsx
@@ -6,7 +6,10 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
-import { Globe, Weight, Moon, Sun, Bell, Smartphone, SettingsIcon } from "lucide-react";
+import { Globe, Weight, Bell, Smartphone, SettingsIcon } from "lucide-react";
+import ThemeSelector from "@/components/theme/ThemeSelector";
+import { useThemeCtx } from "@/components/theme/ThemeProvider";
+import { THEME_STORAGE_KEY, DEFAULT_THEME } from "@/lib/theme";
 import { useToast } from "@/hooks/use-toast";
 
 const LANGUAGES = [
@@ -25,10 +28,10 @@ const LANGUAGES = [
 export default function Settings() {
   const [language, setLanguage] = useState(localStorage.getItem('fitness-app-language') || 'en');
   const [weightUnit, setWeightUnit] = useState(localStorage.getItem('fitness-app-weight-unit') || 'lbs');
-  const [darkMode, setDarkMode] = useState(localStorage.getItem('fitness-app-theme') === 'dark');
   const [notifications, setNotifications] = useState(localStorage.getItem('fitness-app-notifications') !== 'false');
   const [autoRest, setAutoRest] = useState(localStorage.getItem('fitness-app-auto-rest') !== 'false');
   const [restInterval, setRestInterval] = useState(parseInt(localStorage.getItem('fitness-app-rest-interval') || '90', 10));
+  const { setTheme } = useThemeCtx();
   const { toast } = useToast();
 
   const handleLanguageChange = (newLanguage: string) => {
@@ -49,15 +52,6 @@ export default function Settings() {
     });
   };
 
-  const handleDarkModeToggle = (enabled: boolean) => {
-    setDarkMode(enabled);
-    localStorage.setItem('fitness-app-theme', enabled ? 'dark' : 'light');
-    document.documentElement.classList.toggle('dark', enabled);
-    toast({
-      title: "Theme updated",
-      description: `${enabled ? 'Dark' : 'Light'} mode enabled`,
-    });
-  };
 
   const handleNotificationsToggle = (enabled: boolean) => {
     setNotifications(enabled);
@@ -97,17 +91,16 @@ export default function Settings() {
   const resetAllSettings = () => {
     setLanguage('en');
     setWeightUnit('lbs');
-    setDarkMode(false);
     setNotifications(true);
     setAutoRest(true);
-    
+    setTheme(DEFAULT_THEME);
+
     localStorage.removeItem('fitness-app-language');
     localStorage.removeItem('fitness-app-weight-unit');
-    localStorage.removeItem('fitness-app-theme');
     localStorage.removeItem('fitness-app-notifications');
     localStorage.removeItem('fitness-app-auto-rest');
+    localStorage.removeItem(THEME_STORAGE_KEY);
     
-    document.documentElement.classList.remove('dark');
     
     toast({
       title: "Settings reset",
@@ -210,24 +203,11 @@ export default function Settings() {
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center space-x-2">
-              {darkMode ? <Moon className="h-5 w-5" /> : <Sun className="h-5 w-5" />}
               <span>Appearance</span>
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-6">
-            <div className="flex items-center justify-between">
-              <div>
-                <Label htmlFor="dark-mode">Dark Mode</Label>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  Switch between light and dark themes
-                </p>
-              </div>
-              <Switch
-                id="dark-mode"
-                checked={darkMode}
-                onCheckedChange={handleDarkModeToggle}
-              />
-            </div>
+            <ThemeSelector />
           </CardContent>
         </Card>
 

--- a/LiftTrackerAI/styles/themes.css
+++ b/LiftTrackerAI/styles/themes.css
@@ -1,0 +1,63 @@
+/* Base (default / energy) */
+:root {
+  --color-bg:        #F9FAFB;  /* Off White */
+  --color-fg:        #111827;  /* Charcoal for text on light */
+  --color-card:      #FFFFFF;
+  --color-muted:     #6B7280;
+
+  --color-primary:   #3B82F6;  /* Electric Blue */
+  --color-secondary: #22C55E;  /* Neon Green */
+  --color-accent:    #F97316;  /* Sunset Orange */
+
+  --color-success:   #10B981;
+  --color-warning:   #F59E0B;
+  --color-danger:    #DC2626;
+}
+
+/* Dark Pro */
+[data-theme="darkpro"] {
+  --color-bg:        #0B0F17;
+  --color-fg:        #E5E7EB;
+  --color-card:      #111827;
+  --color-muted:     #9CA3AF;
+
+  --color-primary:   #60A5FA;  /* softer blue glow */
+  --color-secondary: #34D399;
+  --color-accent:    #F59E0B;
+}
+
+/* Sunset Glow */
+[data-theme="sunset"] {
+  --color-bg:        #FFF7ED;
+  --color-fg:        #1F2937;
+  --color-card:      #FFFFFF;
+  --color-muted:     #6B7280;
+
+  --color-primary:   #F97316;  /* Orange */
+  --color-secondary: #F43F5E;  /* Rose */
+  --color-accent:    #8B5CF6;  /* Purple */
+}
+
+/* Minimal White */
+[data-theme="minimal"] {
+  --color-bg:        #FFFFFF;
+  --color-fg:        #111827;
+  --color-card:      #F3F4F6;
+  --color-muted:     #6B7280;
+
+  --color-primary:   #2563EB;  /* Deeper blue */
+  --color-secondary: #64748B;  /* Slate for subtle actions */
+  --color-accent:    #0EA5E9;  /* Cyan accent */
+}
+
+/* Retro Arcade */
+[data-theme="arcade"] {
+  --color-bg:        #0A0A0A;
+  --color-fg:        #E5E7EB;
+  --color-card:      #111111;
+  --color-muted:     #A3A3A3;
+
+  --color-primary:   #A78BFA;  /* Neon purple */
+  --color-secondary: #22D3EE;  /* Neon cyan */
+  --color-accent:    #22C55E;  /* Neon green */
+}

--- a/LiftTrackerAI/tailwind.config.ts
+++ b/LiftTrackerAI/tailwind.config.ts
@@ -9,6 +9,7 @@ export default {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
+        '2xl': '1.5rem'
       },
       colors: {
         background: "var(--background)",


### PR DESCRIPTION
## Summary
- add CSS-variable theme palettes and mapping
- implement ThemeProvider, hook, and selector with localStorage persistence
- integrate theme selection into settings UI and app layout

## Testing
- `npm test`
- `npm run check` *(fails: TS2802/TS7006 in lib/coach/rules.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a798287d90832594165513dc4e725e