### PR TITLE
Set modern TypeScript target

### DIFF
--- a/LiftTrackerAI/tsconfig.json
+++ b/LiftTrackerAI/tsconfig.json
@@ -5,6 +5,7 @@
     "incremental": true,
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",
     "noEmit": true,
+    "target": "ES2020",
     "module": "ESNext",
     "strict": true,
     "lib": ["esnext", "dom", "dom.iterable"],


### PR DESCRIPTION
## Summary
- target ES2020 in `tsconfig.json`

## Testing
- `npm test`
- `npm run check`
- `npx eslint -c .eslintrc.cjs .` *(fails: config object uses unsupported `root` key)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a2132ff883259f151c5e54ff053c