### PR TITLE
wire: feed real recent sets into AI Coach; add .env.example; expose ThemeSelector in Settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 LiftTrackerAI/node_modules/
 LiftTrackerAI/dist/
-LiftTrackerAI/.env*
+LiftTrackerAI/.env
+LiftTrackerAI/.env.*
+!LiftTrackerAI/.env.example
 *.log

--- a/LiftTrackerAI/.env.example
+++ b/LiftTrackerAI/.env.example
@@ -1,0 +1,2 @@
+OPENROUTER_API_KEY=YOUR_KEY
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1

--- a/LiftTrackerAI/README.md
+++ b/LiftTrackerAI/README.md
@@ -1,0 +1,7 @@
+# LiftTrackerAI
+
+## Local Setup
+
+1. Copy `.env.example` to `.env` and supply your `OPENROUTER_API_KEY`.
+2. Install dependencies with `npm install`.
+3. Start the development server with `npm run dev`.

--- a/LiftTrackerAI/client/src/pages/dashboard.tsx
+++ b/LiftTrackerAI/client/src/pages/dashboard.tsx
@@ -6,6 +6,7 @@ import { useSettings } from "@/contexts/settings-context";
 import ProgressChart from "@/components/workout/progress-chart";
 import PedometerCard from "@/components/pedometer/pedometer-card";
 import CoachDock from "@/components/coach/Dock";
+import type { SetEntry } from "@/lib/coach/rules";
 import { 
   Home, 
   Calendar, 
@@ -43,6 +44,10 @@ export default function Dashboard() {
     queryKey: ["/api/workout-sessions/active", MOCK_USER_ID],
   });
 
+  const { data: recentSets } = useQuery<SetEntry[]>({
+    queryKey: ["/api/users", MOCK_USER_ID, "sets?limit=30"],
+  });
+
   const handleStartWorkout = () => {
     // TODO: Navigate to workout start flow
     console.log("Start workout");
@@ -64,7 +69,7 @@ export default function Dashboard() {
     return `${diffDays} days ago`;
   };
 
-  const getRecentSets = () => [] as any[];
+  const getRecentSets = () => recentSets ?? [];
 
   return (
     <div className="min-h-screen">

--- a/LiftTrackerAI/client/src/pages/settings.tsx
+++ b/LiftTrackerAI/client/src/pages/settings.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
-import { Globe, Weight, Bell, Smartphone, SettingsIcon } from "lucide-react";
+import { Globe, Weight, Bell, Smartphone, SettingsIcon, Bot } from "lucide-react";
 import ThemeSelector from "@/components/theme/ThemeSelector";
 import { useThemeCtx } from "@/components/theme/ThemeProvider";
 import { THEME_STORAGE_KEY, DEFAULT_THEME } from "@/lib/theme";
@@ -301,6 +301,20 @@ export default function Settings() {
             >
               Reset All Settings
             </Button>
+          </CardContent>
+        </Card>
+
+        {/* AI Coach */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center space-x-2">
+              <Bot className="h-5 w-5" />
+              <span>AI Coach</span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm text-gray-500 dark:text-gray-400">
+            <p>The AI Coach fetches tips from OpenRouter when you're online.</p>
+            <p>If offline, heuristic advice is generated locally.</p>
           </CardContent>
         </Card>
       </div>

--- a/LiftTrackerAI/package.json
+++ b/LiftTrackerAI/package.json
@@ -11,7 +11,8 @@
     "test": "echo \"No tests specified\" && exit 0",
     "db:push": "drizzle-kit push",
     "scrape:exercises": "node scripts/scrape-and-rewrite.mjs",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "lint": "eslint ."
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/LiftTrackerAI/server/routes.ts
+++ b/LiftTrackerAI/server/routes.ts
@@ -215,14 +215,31 @@ export async function registerRoutes(app: Express): Promise<Server> {
     });
 
     // User Stats
+  app.get("/api/users/:userId/sets", async (req, res) => {
+    try {
+      const limit = parseInt((req.query.limit as string) ?? "30", 10);
+      const sets = await storage.getRecentSets(req.params.userId, limit);
+      const mapped = sets.map(s => ({
+        date: s.completedAt.toISOString(),
+        exerciseId: s.exerciseId,
+        reps: s.reps,
+        weight: s.weight ?? 0,
+        rpe: (s as any).rpe,
+      }));
+      res.json(mapped);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch recent sets" });
+    }
+  });
+
   app.get("/api/users/:userId/stats", async (req, res) => {
     try {
       const stats = await storage.getUserStats(req.params.userId);
-    res.json(stats);
-  } catch (error) {
-    res.status(500).json({ message: "Failed to fetch user stats" });
-  }
-});
+      res.json(stats);
+    } catch (error) {
+      res.status(500).json({ message: "Failed to fetch user stats" });
+    }
+  });
 
   app.post("/api/coach/tip", async (req, res) => {
     const Body = z.object({


### PR DESCRIPTION
## Summary
- fetch recent workout sets from `/api/users/:userId/sets` and feed them to the AI Coach on the dashboard
- document environment setup via `.env.example` and README
- surface theme switching and AI Coach information in settings

## Testing
- `npm run lint` *(fails: many token class violations across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a755268883258db402fb70d3ba5c