### PR TITLE
Add OpenRouter API key for AI coach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 LiftTrackerAI/node_modules/
 LiftTrackerAI/dist/
-LiftTrackerAI/.env
 LiftTrackerAI/.env.*
 !LiftTrackerAI/.env.example
+!LiftTrackerAI/.env
 *.log

--- a/LiftTrackerAI/.env
+++ b/LiftTrackerAI/.env
@@ -1,0 +1,2 @@
+OPENROUTER_API_KEY=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
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1


### PR DESCRIPTION
## Summary
- allow committing environment file for LiftTrackerAI
- add OpenRouter API credentials for AI coach

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7adae11ac8325a855f278be5e45de