### PR TITLE
feat(platform): prep Android (Capacitor) + Windows (Tauri) with shared AI Coach config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
-# Copy to .env locally (DO NOT COMMIT .env)
+# Backend key (local dev only; do not commit .env)
 GROQ_API_KEY=your_groq_key_here
 GROQ_MODEL=llama-3.1-8b-instant
 PORT=8080
+
+# Frontend: point to a hosted /api/coach (optional)
+VITE_COACH_URL=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,35 +12,29 @@ jobs:
       GROQ_MODEL: llama-3.1-8b-instant
       PORT: 8080
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      VITE_COACH_URL: ${{ vars.VITE_COACH_URL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Use Node
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "npm"
-
       - name: Install deps
         run: npm ci
-
       - name: Lint (optional)
         run: npm run lint --if-present
-
       - name: Test (optional)
         run: npm test --if-present
-
-      - name: Build TypeScript
+      - name: Build
         run: npm run build --if-present
-
-      - name: Smoke run (compiled server)
+      - name: Smoke server
         if: ${{ github.event_name != 'pull_request' }}
         run: |
           node dist/LiftTrackerAI/server/index.js &
           sleep 3
           curl -sS -X POST http://localhost:8080/api/coach \
             -H "Content-Type: application/json" \
-            -d '{"messages":[{"role":"user","content":"Say ok."}]}' \
-            | tee /tmp/coach.json
+            -d '{"messages":[{"role":"user","content":"Say ok."}]}' | tee /tmp/coach.json
           pkill -f "dist/LiftTrackerAI/server/index.js" || true

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ LiftTrackerAI/dist/
 *.log
 .env
 node_modules/
+android
+src-tauri/target

--- a/LiftTrackerAI/client/coach.ts
+++ b/LiftTrackerAI/client/coach.ts
@@ -1,7 +1,9 @@
+import { COACH_URL } from "../../src/config/coach.js";
+
 export type ChatMsg = { role: "system" | "user" | "assistant"; content: string };
 
 export async function askCoach(messages: ChatMsg[]) {
-  const resp = await fetch("/api/coach", {
+  const resp = await fetch(COACH_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ messages }),
@@ -9,7 +11,7 @@ export async function askCoach(messages: ChatMsg[]) {
   if (!resp.ok) {
     let msg = "Coach API error";
     try {
-      const j: any = await resp.json();
+      const j = await resp.json();
       if (j?.error) msg = j.error;
     } catch {}
     throw new Error(msg);

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,0 +1,13 @@
+import { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.lift.legends',
+  appName: 'Lift Legends',
+  webDir: 'dist',
+  bundledWebRuntime: false,
+  server: {
+    androidScheme: 'https'
+  }
+};
+
+export default config;

--- a/dist/LiftTrackerAI/client/coach.js
+++ b/dist/LiftTrackerAI/client/coach.js
@@ -1,8 +1,6 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.askCoach = askCoach;
-async function askCoach(messages) {
-    const resp = await fetch("/api/coach", {
+import { COACH_URL } from "../../src/config/coach.js";
+export async function askCoach(messages) {
+    const resp = await fetch(COACH_URL, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ messages }),

--- a/dist/LiftTrackerAI/server/index.js
+++ b/dist/LiftTrackerAI/server/index.js
@@ -1,15 +1,10 @@
-"use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-require("dotenv/config");
-const express_1 = __importDefault(require("express"));
-const cors_1 = __importDefault(require("cors"));
-const groq_sdk_1 = __importDefault(require("groq-sdk"));
-const app = (0, express_1.default)();
-app.use((0, cors_1.default)());
-app.use(express_1.default.json({ limit: "1mb" }));
+import "dotenv/config";
+import express from "express";
+import cors from "cors";
+import Groq from "groq-sdk";
+const app = express();
+app.use(cors());
+app.use(express.json({ limit: "1mb" }));
 const GROQ_API_KEY = process.env.GROQ_API_KEY;
 if (!GROQ_API_KEY) {
     console.error("Missing GROQ_API_KEY");
@@ -18,7 +13,7 @@ if (!GROQ_API_KEY) {
 const GROQ_MODEL = process.env.GROQ_MODEL || "llama-3.1-8b-instant";
 // 🔒 Lock here — only allow Llama 3.1 models
 const ALLOWED_MODELS = new Set(["llama-3.1-8b-instant"]);
-const client = new groq_sdk_1.default({ apiKey: GROQ_API_KEY });
+const client = new Groq({ apiKey: GROQ_API_KEY });
 app.post("/api/coach", async (req, res) => {
     try {
         const { messages } = req.body;

--- a/dist/src/config/coach.js
+++ b/dist/src/config/coach.js
@@ -1,0 +1,26 @@
+/**
+ * COACH_URL resolver:
+ * - Use VITE_COACH_URL if set (production/staging).
+ * - Android emulator: 10.0.2.2
+ * - LAN/dev: window.location.origin (if available)
+ * - Tauri: assume local server on 127.0.0.1:8080 unless overridden
+ */
+const fromEnv = import.meta?.env?.VITE_COACH_URL || globalThis?.VITE_COACH_URL;
+function detectDefault() {
+    // Capacitor emulator
+    const isAndroidEmu = typeof navigator !== "undefined" &&
+        /Android/i.test(navigator.userAgent) &&
+        (location.hostname === "10.0.2.2" || location.hostname === "localhost");
+    if (isAndroidEmu)
+        return "http://10.0.2.2:8080/api/coach";
+    // Tauri environment flag
+    const isTauri = typeof window.__TAURI__ !== "undefined";
+    if (isTauri)
+        return "http://127.0.0.1:8080/api/coach";
+    // Browser/webview default
+    if (typeof window !== "undefined" && window.location?.origin) {
+        return `${window.location.origin}/api/coach`;
+    }
+    return "http://localhost:8080/api/coach";
+}
+export const COACH_URL = (fromEnv && String(fromEnv).trim()) || detectDefault();

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,20 @@
+# Mobile/Desktop Build Notes
+
+## Android (Capacitor)
+1) Install tools: Android Studio, SDK, Java 17.
+2) Install deps: `npm i @capacitor/core @capacitor/cli @capacitor/android`
+3) Init Capacitor (once): `npx cap init "Lift Legends" com.lift.legends`
+4) Build web: `npm run build`
+5) Add android: `npx cap add android`
+6) Sync assets: `npx cap sync`
+7) Open Android Studio: `npx cap open android` → build APK/AAB.
+
+`capacitor.config.ts` should point `webDir` to your build output (e.g., "dist").
+
+## Windows (Tauri)
+1) Install Rust + tauri-cli (`cargo install tauri-cli`).
+2) Init: `npx tauri init` and choose your build folder (e.g., `dist`).
+3) Dev: `npm run tauri:dev`
+4) Build: `npm run tauri:build`
+
+In production, set `VITE_COACH_URL` to your hosted API (so the app calls your deployed /api/coach).

--- a/package.json
+++ b/package.json
@@ -4,15 +4,19 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo 'No tests specified' && exit 0",
-    "start:coach": "node dist/LiftTrackerAI/server/index.js",
     "build": "tsc",
-    "dev:coach": "tsx LiftTrackerAI/server/index.ts"
+    "start:coach": "node dist/LiftTrackerAI/server/index.js",
+    "dev:coach": "tsx LiftTrackerAI/server/index.ts",
+    "android:sync": "npx cap sync",
+    "android:open": "npx cap open android",
+    "tauri:dev": "tauri dev",
+    "tauri:build": "tauri build",
+    "test": "echo 'No tests specified' && exit 0"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "lift-legends"
+version = "0.1.0"
+description = "Lift Legends Desktop"
+authors = ["You"]
+edition = "2021"
+
+[build-dependencies]
+tauri-build = "2"
+
+[dependencies]
+tauri = { version = "2", features = ["tray-icon"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,6 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+fn main() {
+  tauri::Builder::default()
+    .run(tauri::generate_context!())
+    .expect("error while running tauri application");
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "beforeBuildCommand": "npm run build",
+    "beforeDevCommand": "npm run dev",
+    "devPath": "http://localhost:5173",
+    "distDir": "../dist"
+  },
+  "package": {
+    "productName": "Lift Legends",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "windows": [
+      {
+        "title": "Lift Legends",
+        "width": 1200,
+        "height": 800,
+        "resizable": true
+      }
+    ],
+    "security": {
+      "csp": null
+    }
+  }
+}

--- a/src/config/coach.ts
+++ b/src/config/coach.ts
@@ -1,0 +1,30 @@
+/**
+ * COACH_URL resolver:
+ * - Use VITE_COACH_URL if set (production/staging).
+ * - Android emulator: 10.0.2.2
+ * - LAN/dev: window.location.origin (if available)
+ * - Tauri: assume local server on 127.0.0.1:8080 unless overridden
+ */
+const fromEnv = (import.meta as any)?.env?.VITE_COACH_URL || (globalThis as any)?.VITE_COACH_URL;
+
+function detectDefault(): string {
+  // Capacitor emulator
+  const isAndroidEmu = typeof navigator !== "undefined" &&
+    /Android/i.test(navigator.userAgent) &&
+    (location.hostname === "10.0.2.2" || location.hostname === "localhost");
+
+  if (isAndroidEmu) return "http://10.0.2.2:8080/api/coach";
+
+  // Tauri environment flag
+  const isTauri = typeof (window as any).__TAURI__ !== "undefined";
+  if (isTauri) return "http://127.0.0.1:8080/api/coach";
+
+  // Browser/webview default
+  if (typeof window !== "undefined" && window.location?.origin) {
+    return `${window.location.origin}/api/coach`;
+  }
+
+  return "http://localhost:8080/api/coach";
+}
+
+export const COACH_URL: string = (fromEnv && String(fromEnv).trim()) || detectDefault();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,9 @@
 {
-  "compilerOptions": 
-  {
+  "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2020"],
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "lib": ["ES2020", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "strict": true,
@@ -14,5 +13,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["LiftTrackerAI/server/index.ts", "LiftTrackerAI/client/coach.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "android", "src-tauri/target"]
 }


### PR DESCRIPTION
## Summary
- add cross-platform `COACH_URL` resolver with Android, Tauri and browser defaults
- point client helper to shared URL config
- document Android/Tauri build steps and add Capacitor/Tauri scaffolding
- extend env template, CI workflow and scripts for mobile/desktop builds

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7e0aa3b0083258a873163845b5e0e