### PR TITLE
feat: add exercise search dropdown

### DIFF
--- a/LiftTrackerAI/client/src/components/workout/exercise-combobox.tsx
+++ b/LiftTrackerAI/client/src/components/workout/exercise-combobox.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { Exercise } from "@shared/schema";
+
+interface ExerciseComboboxProps {
+  exercises: Exercise[];
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function ExerciseCombobox({ exercises, value, onChange }: ExerciseComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const selected = exercises.find((ex) => ex.id === value);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-full justify-between"
+        >
+          {selected ? selected.name : "Select exercise"}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[300px] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search exercises..." />
+          <CommandList>
+            <CommandEmpty>No exercise found.</CommandEmpty>
+            <CommandGroup>
+              {exercises.map((ex) => (
+                <CommandItem
+                  key={ex.id}
+                  value={ex.name}
+                  onSelect={() => {
+                    onChange(ex.id);
+                    setOpen(false);
+                  }}
+                >
+                  {ex.name}
+                  <Check
+                    className={cn(
+                      "ml-auto h-4 w-4",
+                      value === ex.id ? "opacity-100" : "opacity-0"
+                    )}
+                  />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export default ExerciseCombobox;
+

--- a/LiftTrackerAI/client/src/components/workout/exercise-logger.tsx
+++ b/LiftTrackerAI/client/src/components/workout/exercise-logger.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import ExerciseCombobox from "@/components/workout/exercise-combobox";
 import { Card, CardContent } from "@/components/ui/card";
 import { useToast } from "@/hooks/use-toast";
 import { useSettings } from "@/contexts/settings-context";
@@ -135,18 +135,11 @@ export default function ExerciseLogger({ sessionId, onSetLogged }: ExerciseLogge
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <Label htmlFor="exercise">Exercise</Label>
-            <Select value={selectedExerciseId} onValueChange={setSelectedExerciseId}>
-              <SelectTrigger>
-                <SelectValue placeholder="Select exercise" />
-              </SelectTrigger>
-              <SelectContent>
-                {exercises?.map((exercise) => (
-                  <SelectItem key={exercise.id} value={exercise.id}>
-                    {exercise.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <ExerciseCombobox
+              exercises={exercises ?? []}
+              value={selectedExerciseId}
+              onChange={setSelectedExerciseId}
+            />
           </div>
 
           {/* Exercise tips */}

--- a/LiftTrackerAI/client/src/pages/workout-plan-form.tsx
+++ b/LiftTrackerAI/client/src/pages/workout-plan-form.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import ExerciseCombobox from "@/components/workout/exercise-combobox";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 import type { Exercise, WorkoutPlan } from "@shared/schema";
@@ -305,21 +306,11 @@ export default function WorkoutPlanForm() {
                     >
                   <div className="md:col-span-2">
                     <Label>Exercise</Label>
-                    <Select
+                    <ExerciseCombobox
+                      exercises={exercises ?? []}
                       value={row.exerciseId}
-                      onValueChange={(val) => updateRow(idx, "exerciseId", val)}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select exercise" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {exercises?.map((ex) => (
-                          <SelectItem key={ex.id} value={ex.id}>
-                            {ex.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                      onChange={(val) => updateRow(idx, "exerciseId", val)}
+                    />
                     {exercise?.tips && (
                       <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 italic">
                         Tip: {exercise.tips}


### PR DESCRIPTION
## Summary
- add combobox component for searching exercises
- use searchable exercise dropdown in logger and plan form

## Testing
- `npm test`
- `cd LiftTrackerAI && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acf72e028c8325be60a9b98954da09