### PR TITLE
feat: replace combobox trigger button with input field

### DIFF
--- a/LiftTrackerAI/client/src/components/workout/exercise-combobox.tsx
+++ b/LiftTrackerAI/client/src/components/workout/exercise-combobox.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   Command,
@@ -9,7 +9,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import { Check, ChevronsUpDown } from "lucide-react";
+import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Exercise } from "@shared/schema";
 
@@ -21,24 +21,52 @@ interface ExerciseComboboxProps {
 
 export function ExerciseCombobox({ exercises, value, onChange }: ExerciseComboboxProps) {
   const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
   const selected = exercises.find((ex) => ex.id === value);
 
+  const handleOpen = () => setOpen(true);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open) {
+      handleOpen();
+      if (e.key.length === 1 && !e.ctrlKey && !e.altKey && !e.metaKey) {
+        setSearch(e.key);
+      }
+      if (e.key === "Backspace") {
+        setSearch("");
+      }
+      e.preventDefault();
+    }
+  };
+
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o);
+        if (!o) setSearch("");
+      }}
+    >
       <PopoverTrigger asChild>
-        <Button
-          variant="outline"
+        <Input
           role="combobox"
           aria-expanded={open}
-          className="w-full justify-between"
-        >
-          {selected ? selected.name : "Select exercise"}
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
+          className="w-full"
+          value={selected ? selected.name : ""}
+          placeholder="Select exercise"
+          readOnly
+          onFocus={handleOpen}
+          onKeyDown={handleKeyDown}
+        />
       </PopoverTrigger>
       <PopoverContent className="w-[300px] p-0" align="start">
         <Command>
-          <CommandInput placeholder="Search exercises..." />
+          <CommandInput
+            placeholder="Search exercises..."
+            autoFocus
+            value={search}
+            onValueChange={setSearch}
+          />
           <CommandList>
             <CommandEmpty>No exercise found.</CommandEmpty>
             <CommandGroup>
@@ -49,6 +77,7 @@ export function ExerciseCombobox({ exercises, value, onChange }: ExerciseCombobo
                   onSelect={() => {
                     onChange(ex.id);
                     setOpen(false);
+                    setSearch("");
                   }}
                 >
                   {ex.name}


### PR DESCRIPTION
## Summary
- allow typing directly into ExerciseCombobox by replacing trigger button with input
- auto-focus CommandInput and open suggestions on focus or key press
- selecting an item updates value and closes the popover

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfb5b40048325a5a28cb581d4e81e