### PR TITLE
feat: require exercise selection for workout plan rows

### DIFF
--- a/LiftTrackerAI/client/src/pages/workout-plan-form.tsx
+++ b/LiftTrackerAI/client/src/pages/workout-plan-form.tsx
@@ -131,7 +131,7 @@ export default function WorkoutPlanForm() {
     setRows((prev) => [
       ...prev,
       {
-        exerciseId: exercises && exercises.length > 0 ? exercises[0].id : "",
+        exerciseId: "",
         sets: 3,
         reps: 8,
         weight: undefined,
@@ -311,10 +311,14 @@ export default function WorkoutPlanForm() {
                       value={row.exerciseId}
                       onChange={(val) => updateRow(idx, "exerciseId", val)}
                     />
-                    {exercise?.tips && (
-                      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 italic">
-                        Tip: {exercise.tips}
-                      </p>
+                    {row.exerciseId === "" ? (
+                      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Select exercise</p>
+                    ) : (
+                      exercise?.tips && (
+                        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 italic">
+                          Tip: {exercise.tips}
+                        </p>
+                      )
                     )}
                   </div>
                   <div>


### PR DESCRIPTION
## Summary
- start new plan rows without a preselected exercise
- show placeholder text until an exercise is chosen

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acfb5c3b9483259325baeb3b8a1b1a