### PR TITLE
feat: add hint text to exercise combobox

### DIFF
--- a/LiftTrackerAI/client/src/components/workout/exercise-combobox.tsx
+++ b/LiftTrackerAI/client/src/components/workout/exercise-combobox.tsx
@@ -9,7 +9,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import { Check, ChevronsUpDown } from "lucide-react";
+import { Check, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Exercise } from "@shared/schema";
 
@@ -32,8 +32,12 @@ export function ExerciseCombobox({ exercises, value, onChange }: ExerciseCombobo
           aria-expanded={open}
           className="w-full justify-between"
         >
-          {selected ? selected.name : "Select exercise"}
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          {selected ? (
+            selected.name
+          ) : (
+            <span className="text-muted-foreground">Click to search exercises</span>
+          )}
+          <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[300px] p-0" align="start">

--- a/LiftTrackerAI/lib/db/repo.ts
+++ b/LiftTrackerAI/lib/db/repo.ts
@@ -56,7 +56,10 @@ export async function exportAll() {
 }
 export async function importAll(payload: any, merge = true) {
   const { prefs = [], workouts = [], sets = [], voice = [], tips = [] } = payload || {};
-  await localdb.transaction('rw', localdb.userPrefs, localdb.workouts, localdb.sets, localdb.voiceLogs, localdb.coachTips, async () => {
+  await localdb.transaction(
+    'rw',
+    [localdb.userPrefs, localdb.workouts, localdb.sets, localdb.voiceLogs, localdb.coachTips],
+    async () => {
     if (!merge) {
       await Promise.all([
         localdb.userPrefs.clear(), localdb.workouts.clear(),


### PR DESCRIPTION
## Summary
- show placeholder text "Click to search exercises" in exercise combobox trigger
- indicate dropdown with chevron-down icon
- wrap Dexie tables in array during import to satisfy transaction typings

## Testing
- `npm test`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68acfb5d56f88325ad684fae46e63264