### PR TITLE
feat(ui): add Lift Legends branding and workout home layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,10 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title>Lift Legends – Exercise Demo</title>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width,initial-scale=1"/>
+    <title>Lift Legends</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml"/>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,10 @@
         "express": "^5.1.0",
         "fuse.js": "^7.1.0",
         "groq-sdk": "^0.30.0",
+        "lucide-react": "^0.541.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.2"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
@@ -2338,6 +2340,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.541.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.541.0.tgz",
+      "integrity": "sha512-s0Vircsu5WaGv2KoJZ5+SoxiAJ3UXV5KqEM3eIFDHaHkcLIFdIWgXtZ412+Gh02UsdS7Was+jvEpBvPCWQISlg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2662,6 +2673,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
+      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.2.tgz",
+      "integrity": "sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2826,6 +2884,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "express": "^5.1.0",
     "fuse.js": "^7.1.0",
     "groq-sdk": "^0.30.0",
+    "lucide-react": "^0.541.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,18 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Lift Legends">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="512" y2="512" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#5CC0FF"/>
+      <stop offset="1" stop-color="#2B7FFF"/>
+    </linearGradient>
+  </defs>
+  <!-- Shield -->
+  <path d="M256 36l168 60v132c0 110-74 206-168 248C162 434 88 338 88 228V96l168-60z" fill="#0E1621" stroke="url(#g)" stroke-width="12"/>
+  <!-- Dumbbell -->
+  <g transform="translate(0,8)">
+    <rect x="150" y="208" width="212" height="36" rx="6" fill="url(#g)"/>
+    <rect x="120" y="188" width="28" height="76" rx="6" fill="#5CC0FF"/>
+    <rect x="366" y="188" width="28" height="76" rx="6" fill="#5CC0FF"/>
+  </g>
+  <!-- LL Monogram -->
+  <path d="M192 160v136h64v-28h-36V160h-28zm92 0v136h76v-28h-48V160h-28z" fill="#E8F1FF"/>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Routes, Route } from "react-router-dom";
+import WorkoutHome from "./pages/WorkoutHome";
+import Profile from "./pages/Profile";
+import History from "./pages/History";
+import Exercises from "./pages/Exercises";
+import Measure from "./pages/Measure";
+import BottomTabs from "./components/BottomTabs";
+import "./styles/theme.css";
+
+export default function App(){
+  return (
+    <>
+      <Routes>
+        <Route path="/" element={<WorkoutHome/>} />
+        <Route path="/profile" element={<Profile/>} />
+        <Route path="/history" element={<History/>} />
+        <Route path="/exercises" element={<Exercises/>} />
+        <Route path="/measure" element={<Measure/>} />
+      </Routes>
+      <BottomTabs/>
+    </>
+  );
+}

--- a/src/assets/lift-legends-logo.svg
+++ b/src/assets/lift-legends-logo.svg
@@ -1,0 +1,18 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Lift Legends">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="512" y2="512" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#5CC0FF"/>
+      <stop offset="1" stop-color="#2B7FFF"/>
+    </linearGradient>
+  </defs>
+  <!-- Shield -->
+  <path d="M256 36l168 60v132c0 110-74 206-168 248C162 434 88 338 88 228V96l168-60z" fill="#0E1621" stroke="url(#g)" stroke-width="12"/>
+  <!-- Dumbbell -->
+  <g transform="translate(0,8)">
+    <rect x="150" y="208" width="212" height="36" rx="6" fill="url(#g)"/>
+    <rect x="120" y="188" width="28" height="76" rx="6" fill="#5CC0FF"/>
+    <rect x="366" y="188" width="28" height="76" rx="6" fill="#5CC0FF"/>
+  </g>
+  <!-- LL Monogram -->
+  <path d="M192 160v136h64v-28h-36V160h-28zm92 0v136h76v-28h-48V160h-28z" fill="#E8F1FF"/>
+</svg>

--- a/src/components/BottomTabs.tsx
+++ b/src/components/BottomTabs.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+import { User2, History, PlusCircle, Dumbbell, Ruler } from "lucide-react";
+
+const items = [
+  { to: "/profile",   label: "Profile",   Icon: User2 },
+  { to: "/history",   label: "History",   Icon: History },
+  { to: "/",          label: "Workout",   Icon: PlusCircle },
+  { to: "/exercises", label: "Exercises", Icon: Dumbbell },
+  { to: "/measure",   label: "Measure",   Icon: Ruler },
+];
+
+export default function BottomTabs() {
+  const { pathname } = useLocation();
+  return (
+    <nav className="bottom-tabs">
+      <div className="tabs-inner">
+        {items.map(({to,label,Icon}) => {
+          const active = (to === "/" ? pathname === "/" : pathname.startsWith(to));
+          return (
+            <Link key={to} to={to} className={`tab ${active ? "active" : ""}`}>
+              <Icon className="ico" strokeWidth={2.2}/>
+              <span>{label}</span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import ExerciseFormDemo from "./pages/ExerciseFormDemo";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <ExerciseFormDemo />
+    <BrowserRouter>
+      <App/>
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/Exercises.tsx
+++ b/src/pages/Exercises.tsx
@@ -1,0 +1,2 @@
+import React from "react";
+export default function Exercises(){ return <div className="container" style={{paddingTop:24}}><h2>Exercises</h2><p className="subtle">Browse or search exercises.</p></div>; }

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -1,0 +1,2 @@
+import React from "react";
+export default function History(){ return <div className="container" style={{paddingTop:24}}><h2>History</h2><p className="subtle">Past workouts will appear here.</p></div>; }

--- a/src/pages/Measure.tsx
+++ b/src/pages/Measure.tsx
@@ -1,0 +1,2 @@
+import React from "react";
+export default function Measure(){ return <div className="container" style={{paddingTop:24}}><h2>Measure</h2><p className="subtle">Track body measurements.</p></div>; }

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,2 @@
+import React from "react";
+export default function Profile(){ return <div className="container" style={{paddingTop:24}}><h2>Profile</h2><p className="subtle">Your account and settings.</p></div>; }

--- a/src/pages/WorkoutHome.tsx
+++ b/src/pages/WorkoutHome.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { MoreHorizontal, Plus, CalendarDays, Search } from "lucide-react";
+import logo from "../assets/lift-legends-logo.svg";
+
+type Template = { id: string; title: string; exercises: string[]; date: string };
+const templates: Template[] = [
+  { id: "t1", title: "PHAT Back and s...", exercises: ["Seated Overhead Press (Barbell)", "Seated Overhead ..."], date: "Dec 9, 2023" },
+  { id: "t2", title: "PHAT legs hypertrophy", exercises: ["Squat (Barbell)", "Bulgarian Split Squat, Cross Body..."], date: "Sep 2, 2023" },
+  { id: "t3", title: "PHAT chest and triceps", exercises: ["Bench Press (Barbell)", "Incline Bench Press (Barb..."], date: "Feb 18, 2025" },
+  { id: "t4", title: "PHAT Lower body", exercises: ["Squat (Barbell)", "Hack Squat (Barbell), Lunge (D..."], date: "Jun 29, 2022" },
+];
+
+export default function WorkoutHome() {
+  return (
+    <div className="app">
+      <header className="app-header">
+        <img src={logo} alt="Lift Legends" style={{width:32,height:32,opacity:.9}} />
+        <div className="h1">Workout</div>
+        <div className="subtle">Quick start</div>
+        <div className="container" style={{padding: "10px 0 0"}}>
+          <button className="quick">START AN EMPTY WORKOUT</button>
+        </div>
+      </header>
+
+      <main className="container">
+        <div className="row">
+          <h2>Templates</h2>
+          <div style={{display:"flex",gap:10}}>
+            <button className="icon-btn" title="Add"><Plus size={18}/></button>
+            <button className="icon-btn" title="Import"><CalendarDays size={18}/></button>
+            <button className="icon-btn" title="More"><MoreHorizontal size={18}/></button>
+          </div>
+        </div>
+
+        <div className="grid">
+          {templates.map(t => (
+            <article key={t.id} className="card">
+              <div style={{display:"flex", justifyContent:"space-between", alignItems:"center"}}>
+                <h3>{t.title}</h3>
+                <button className="icon-btn" aria-label="More"><MoreHorizontal size={18}/></button>
+              </div>
+              <p>{t.exercises.join(", ")}</p>
+              <div className="meta">
+                <span className="badge">Saved</span>
+                <span style={{marginLeft:"auto"}}>{t.date}</span>
+              </div>
+            </article>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,103 @@
+:root {
+  --bg: #0b1118;            /* page background */
+  --panel: #111a24;         /* cards, app bar */
+  --text: #e6edf6;          /* primary text */
+  --muted: #9fb3c8;         /* secondary text */
+  --border: #223040;
+  --primary: #2b7fff;       /* buttons, accents */
+  --primary-600: #2b6fe6;
+  --primary-300: #5cc0ff;
+  --success: #3bd27f;
+  --danger: #ff6574;
+  --radius: 14px;
+  --shadow: 0 10px 30px rgba(0,0,0,.35);
+}
+
+* { box-sizing: border-box; }
+html, body, #root { height: 100%; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji","Segoe UI Emoji", "Segoe UI Symbol";
+  background: var(--bg);
+  color: var(--text);
+}
+
+/* App header and content */
+.app {
+  min-height: 100%;
+  display: flex; flex-direction: column;
+}
+.app-header {
+  padding: 28px 20px 10px;
+  position: sticky; top: 0; z-index: 5;
+  background: linear-gradient(180deg, rgba(11,17,24,.98) 0%, rgba(11,17,24,.92) 65%, rgba(11,17,24,0) 100%);
+  backdrop-filter: blur(6px);
+}
+.h1 { font-size: 40px; font-weight: 700; letter-spacing: .3px; margin: 8px 0 4px; }
+.subtle { color: var(--muted); font-size: 16px; }
+
+.container { padding: 0 20px; }
+
+.quick {
+  background: var(--primary);
+  color: white;
+  font-weight: 700;
+  border: 0;
+  border-radius: 12px;
+  padding: 14px 18px;
+  width: 100%;
+  box-shadow: var(--shadow);
+}
+.quick:active { transform: translateY(1px); background: var(--primary-600); }
+
+.row { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin: 18px 0 12px; }
+.row h2 { margin: 0; font-size: 24px; }
+.icon-btn {
+  width: 40px; height: 40px; border-radius: 12px; border: 1px solid var(--border);
+  display: grid; place-items: center; background: var(--panel); color: var(--text);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0,1fr));
+  gap: 14px;
+  padding-bottom: 80px; /* leave room for tabs */
+}
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px;
+  box-shadow: 0 2px 8px rgba(0,0,0,.25);
+}
+.card h3 { margin: 2px 0 6px; font-size: 20px; }
+.card p  { margin: 6px 0; color: var(--muted); font-size: 13px; line-height: 1.45; }
+.card .meta { margin-top: 8px; display: flex; gap: 6px; align-items: center; color: var(--muted); font-size: 12px; }
+
+.badge {
+  display: inline-block;
+  padding: 4px 8px;
+  background: rgba(44,127,255,.12);
+  border: 1px solid rgba(44,127,255,.35);
+  border-radius: 999px;
+  color: var(--primary-300);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.bottom-tabs {
+  position: fixed; left: 0; right: 0; bottom: 0; z-index: 10;
+  background: rgba(16,24,33,.9);
+  backdrop-filter: blur(8px);
+  border-top: 1px solid var(--border);
+}
+.tabs-inner {
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  padding: 10px 8px 14px;
+}
+.tab {
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  color: var(--muted); text-decoration: none; font-size: 12px;
+}
+.tab.active { color: var(--primary-300); }
+.tab .ico { width: 24px; height: 24px; }


### PR DESCRIPTION
## Summary
- add Lift Legends logo and dark theme variables
- implement Workout Home screen and bottom tab navigation
- wire up router and placeholder pages

## Testing
- `npx tsc`
- `npm test`
- `git push` *(fails: No configured push destination)*

------
https://chatgpt.com/codex/tasks/task_e_68ad106852c48325bcd3cda04a916987