### PR TITLE
Add empty workout navigation

### DIFF
--- a/LiftTrackerAI/server/exercisesRoute.ts
+++ b/LiftTrackerAI/server/exercisesRoute.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from "express";
+// @ts-ignore: fuse.js has no type declarations
 import Fuse from "fuse.js";
 import fs from "fs";
 import path from "path";
@@ -34,7 +35,7 @@ export function initExerciseRoute(app: any) {
     if (!q) {
       return res.json(EXERCISES.slice(0, limit));
     }
-    const results = FUSE!.search(q, { limit }).map(r => r.item);
+    const results = FUSE!.search(q, { limit }).map((r: any) => r.item);
     return res.json(results);
   });
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Routes, Route } from "react-router-dom";
 import WorkoutHome from "./pages/WorkoutHome";
+import WorkoutSession from "./pages/WorkoutSession";
 import Profile from "./pages/Profile";
 import History from "./pages/History";
 import Exercises from "./pages/Exercises";
@@ -17,6 +18,7 @@ export default function App(){
         <Route path="/history" element={<History/>} />
         <Route path="/exercises" element={<Exercises/>} />
         <Route path="/measure" element={<Measure/>} />
+        <Route path="/workout/new" element={<WorkoutSession/>} />
       </Routes>
       <BottomTabs/>
     </>

--- a/src/pages/WorkoutHome.tsx
+++ b/src/pages/WorkoutHome.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { MoreHorizontal, Plus, CalendarDays, Search } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import logo from "../assets/lift-legends-logo.svg";
 
 type Template = { id: string; title: string; exercises: string[]; date: string };
@@ -11,6 +12,7 @@ const templates: Template[] = [
 ];
 
 export default function WorkoutHome() {
+  const navigate = useNavigate();
   return (
     <div className="app">
       <header className="app-header">
@@ -18,7 +20,7 @@ export default function WorkoutHome() {
         <div className="h1">Workout</div>
         <div className="subtle">Quick start</div>
         <div className="container" style={{padding: "10px 0 0"}}>
-          <button className="quick">START AN EMPTY WORKOUT</button>
+          <button className="quick" onClick={() => navigate("/workout/new")}>START AN EMPTY WORKOUT</button>
         </div>
       </header>
 

--- a/src/pages/WorkoutSession.tsx
+++ b/src/pages/WorkoutSession.tsx
@@ -1,0 +1,20 @@
+import React, { useState } from "react";
+import ExerciseTypeahead from "../components/ExerciseTypeahead";
+
+export default function WorkoutSession() {
+  const [exercise, setExercise] = useState("");
+
+  return (
+    <div className="container" style={{ paddingTop: 24 }}>
+      <h2>Start Workout</h2>
+      <p className="subtle">Add exercises to begin.</p>
+      <ExerciseTypeahead
+        value={exercise}
+        onChange={setExercise}
+        onSelect={(item) => console.log("Selected:", item)}
+        placeholder="e.g., bench, squat, deadlift…"
+        autoFocus
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Navigate to a new workout session when "Start an empty workout" is clicked
- Add WorkoutSession page with exercise typeahead to begin building a workout
- Fix TypeScript build by ignoring missing fuse.js types and typing search results

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad1534fd608325bddb409b404922fa