### PR TITLE
Allow removing exercises and add button to add more

### DIFF
--- a/src/components/ExercisePicker.tsx
+++ b/src/components/ExercisePicker.tsx
@@ -38,7 +38,6 @@ export default function ExercisePicker({ onAdd, onClose }: Props) {
 
   const addAndClose = () => {
     onAdd(Object.values(selected));
-    onClose();
   };
 
   const hasSelection = Object.keys(selected).length > 0;

--- a/src/pages/WorkoutSession.tsx
+++ b/src/pages/WorkoutSession.tsx
@@ -84,6 +84,10 @@ export default function WorkoutSession() {
     );
   };
 
+  const removeExercise = (idx: number) => {
+    setExercises((prev) => prev.filter((_, i) => i !== idx));
+  };
+
   const format = (s: number) => {
     const m = Math.floor(s / 60);
     const sec = s % 60;
@@ -105,7 +109,17 @@ export default function WorkoutSession() {
           key={idx}
           style={{ marginTop: 32, borderTop: "1px solid #eee", paddingTop: 16 }}
         >
-          <h3 style={{ marginBottom: 8 }}>{ex.name}</h3>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              marginBottom: 8,
+            }}
+          >
+            <h3 style={{ marginBottom: 0 }}>{ex.name}</h3>
+            <button onClick={() => removeExercise(idx)}>Remove</button>
+          </div>
           {ex.sets.map((s, sIdx) => (
             <div
               key={sIdx}
@@ -165,6 +179,11 @@ export default function WorkoutSession() {
           </div>
         </div>
       ))}
+      {exercises.length > 0 && (
+        <div style={{ marginTop: 32 }}>
+          <button onClick={() => setShowPicker(true)}>Add Exercise</button>
+        </div>
+      )}
       {showPicker && (
         <ExercisePicker
           onAdd={(items) => {


### PR DESCRIPTION
## Summary
- Add `removeExercise` helper and UI to drop exercises from a session
- Show extra "Add Exercise" button after the list for adding more exercises later
- Ensure the exercise picker closes after adding to keep the session view clear

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad29a1e8dc8325b8af58d771d5bf48