### PR TITLE
feat: platform polish, theme, units, plates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@capacitor/core": "^7.4.3",
+        "@capacitor/haptics": "^7.0.2",
+        "@tauri-apps/api": "^2.8.0",
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
@@ -327,6 +330,24 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@capacitor/core": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-7.4.3.tgz",
+      "integrity": "sha512-wCWr8fQ9Wxn0466vPg7nMn0tivbNVjNy1yL4GvDSIZuZx7UpU2HeVGNe9QjN/quEd+YLRFeKEBLBw619VqUiNg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/haptics": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/haptics/-/haptics-7.0.2.tgz",
+      "integrity": "sha512-vqfeEM6s2zMgLjpITCTUIy7P/hadq/Gr5E/RClFgMJPB41Y5FsqOKD+j85/uwh8N2cf/aWaPeXUmjnTzJbEB2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1096,6 +1117,16 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tauri-apps/api": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.8.0.tgz",
+      "integrity": "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw==",
+      "license": "Apache-2.0 OR MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3092,7 +3123,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
+    "@capacitor/core": "^7.4.3",
+    "@capacitor/haptics": "^7.0.2",
+    "@tauri-apps/api": "^2.8.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,9 +13,12 @@
     "windows": [
       {
         "title": "Lift Legends",
-        "width": 1200,
-        "height": 800,
-        "resizable": true
+        "decorations": false,
+        "transparent": false,
+        "fullscreen": false,
+        "resizable": true,
+        "width": 1100,
+        "height": 750
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,16 +4,29 @@ import SideNav from "./components/SideNav";
 import FAB from "./components/FAB";
 import BottomSheet from "./components/BottomSheet";
 import FinishBar from "./components/FinishBar";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useWorkoutStore } from "./store/workout";
+import { isTauri } from "./lib/env";
+import Titlebar from "./targets/tauri/Titlebar";
+import { applyTheme, bindSystemTheme } from "./lib/theme";
 
 export default function App() {
   const [open, setOpen] = useState(false);
   const loc = useLocation();
   const hasActive = useWorkoutStore((s) => !!s.activeWorkout);
+  const theme = useWorkoutStore((s) => s.settings.theme);
+  const tauri = isTauri();
+
+  useEffect(() => {
+    applyTheme(theme);
+    const off = bindSystemTheme(theme, () => applyTheme(theme));
+    return off;
+  }, [theme]);
 
   return (
-    <div className="min-h-dvh bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-50">
+    <>
+      {tauri && <Titlebar />}
+      <div className={tauri ? "pt-8 min-h-dvh bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-50" : "min-h-dvh bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-50"}>
       {/* Desktop side navigation */}
       <div className="hidden md:flex fixed inset-y-0 left-0 w-64 border-r border-neutral-200 dark:border-neutral-800 p-4">
         <SideNav />
@@ -65,6 +78,7 @@ export default function App() {
 
       {/* Finish workout call-to-action */}
       {hasActive && <FinishBar />}
-    </div>
+      </div>
+    </>
   );
 }

--- a/src/components/FinishBar.tsx
+++ b/src/components/FinishBar.tsx
@@ -1,4 +1,5 @@
 import { useWorkoutStore } from "../store/workout";
+import { hapticSuccess } from "../lib/haptics";
 
 export default function FinishBar() {
   const finishWorkout = useWorkoutStore((s) => s.finishWorkout);
@@ -12,7 +13,10 @@ export default function FinishBar() {
   return (
     <div className="fixed inset-x-0 bottom-0 z-40 mx-auto max-w-3xl p-3">
       <button
-        onClick={finishWorkout}
+        onClick={() => {
+          hapticSuccess();
+          finishWorkout();
+        }}
         className="w-full h-12 rounded-xl bg-black text-white shadow-lg dark:bg-white dark:text-black"
       >
         Finish Workout • {setCount} sets

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from "react";
+
+export default function Modal({ open, onClose, title, children }: { open: boolean; onClose: () => void; title?: string; children: ReactNode }) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="relative w-full max-w-lg rounded-xl bg-white p-4 dark:bg-neutral-900">
+        {title && <div className="mb-2 text-lg font-semibold">{title}</div>}
+        {children}
+      </div>
+      <button
+        className="absolute inset-0 cursor-default"
+        aria-label="Close"
+        onClick={onClose}
+      />
+    </div>
+  );
+}

--- a/src/components/PlateModal.tsx
+++ b/src/components/PlateModal.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useMemo, useState } from "react";
+import Modal from "./Modal";
+import { planPlates } from "../utils/plates";
+import { fromUserUnits, toUserUnits, unitLabel } from "../lib/units";
+import { useWorkoutStore } from "../store/workout";
+
+export default function PlateModal({
+  open, onClose, initialTarget
+}: { open: boolean; onClose: () => void; initialTarget?: number }) {
+  const settings = useWorkoutStore((s) => s.settings);
+  const unit = settings.unit;
+  const [target, setTarget] = useState<number>(initialTarget ?? 60);
+  const [bar, setBar] = useState<number>(unit === "kg" ? (settings.barWeightKg ?? 20) : 45);
+  const [avail, setAvail] = useState<string>(unit === "kg" ? "25,20,15,10,5,2.5,1.25" : "45,35,25,10,5,2.5");
+
+  useEffect(() => {
+    if (open) setTarget(initialTarget ?? target);
+  }, [open, initialTarget]);
+
+  const plan = useMemo(() => {
+    const totalKg = fromUserUnits(target, unit);
+    const barKg = fromUserUnits(bar, unit);
+    const availableKg = avail.split(",").map((x) => Number(x.trim())).filter(Boolean).map((x) => fromUserUnits(x, unit));
+    return planPlates(totalKg, barKg, availableKg);
+  }, [target, bar, avail, unit]);
+
+  return (
+    <Modal open={open} onClose={onClose} title="Plate Calculator">
+      <div className="space-y-3">
+        <div className="grid sm:grid-cols-3 gap-2">
+          <label className="space-y-1">
+            <div className="text-sm">Target ({unitLabel(unit)})</div>
+            <input type="number" value={target} onChange={(e) => setTarget(Number(e.target.value || 0))}
+              className="h-10 w-full rounded-lg border px-3 border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900" />
+          </label>
+          <label className="space-y-1">
+            <div className="text-sm">Bar ({unitLabel(unit)})</div>
+            <input type="number" value={bar} onChange={(e) => setBar(Number(e.target.value || 0))}
+              className="h-10 w-full rounded-lg border px-3 border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900" />
+          </label>
+          <label className="space-y-1 sm:col-span-3">
+            <div className="text-sm">Available plates (comma separated, {unitLabel(unit)})</div>
+            <input value={avail} onChange={(e) => setAvail(e.target.value)}
+              className="h-10 w-full rounded-lg border px-3 border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900" />
+          </label>
+        </div>
+
+        <div className="rounded-xl border p-3 border-neutral-200 dark:border-neutral-800">
+          <div className="text-sm opacity-70 mb-2">Per side</div>
+          <div className="flex flex-wrap gap-2">
+            {plan.perSide.length === 0 ? <span className="text-sm opacity-70">None</span> :
+              plan.perSide.map((p, i) => (
+                <span key={i} className="text-sm rounded-full border px-2 py-0.5 border-neutral-300 dark:border-neutral-700">
+                  {toUserUnits(p, unit)} {unitLabel(unit)}
+                </span>
+              ))}
+          </div>
+          {plan.remainder > 0.001 && (
+            <div className="mt-2 text-xs opacity-70">
+              Remainder per side: {toUserUnits(plan.remainder, unit)} {unitLabel(unit)}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end">
+          <button onClick={onClose} className="h-10 px-4 rounded-lg bg-black text-white dark:bg-white dark:text-black">Close</button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/SetRow.tsx
+++ b/src/components/SetRow.tsx
@@ -1,15 +1,20 @@
 import { useState } from "react";
 import { useWorkoutStore } from "../store/workout";
 import { isVoiceSupported, startDictation, parseWeightReps } from "../utils/voice";
+import { fromUserUnits, unitLabel } from "../lib/units";
+import PlateModal from "./PlateModal";
+import { hapticTap } from "../lib/haptics";
 
 type Props = { exId: string; setId: string };
 
 export default function SetRow({ exId, setId }: Props) {
   const completeSet = useWorkoutStore((s) => s.completeSet);
+  const unit = useWorkoutStore((s) => s.settings.unit);
   const [weight, setWeight] = useState<string>("");
   const [reps, setReps] = useState<string>("");
   const [rpe, setRpe] = useState<string>("");
   const [listening, setListening] = useState(false);
+  const [openPlates, setOpenPlates] = useState(false);
 
   const onVoice = () => {
     if (!isVoiceSupported()) return alert("Voice input not supported in this browser.");
@@ -22,8 +27,8 @@ export default function SetRow({ exId, setId }: Props) {
   };
 
   return (
-    <div className="grid grid-cols-[1fr_1fr_1fr_auto_auto] gap-2 items-center">
-      <input inputMode="decimal" placeholder="kg" value={weight}
+    <div className="grid grid-cols-[1fr_1fr_1fr_auto_auto_auto] gap-2 items-center">
+      <input inputMode="decimal" placeholder={unitLabel(unit)} value={weight}
         onChange={(e) => setWeight(e.target.value)}
         className="h-10 rounded-lg px-3 border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900" />
       <input inputMode="numeric" placeholder="reps" value={reps}
@@ -36,18 +41,25 @@ export default function SetRow({ exId, setId }: Props) {
         className={`h-10 px-3 rounded-lg border ${listening ? "border-green-500" : "border-neutral-300 dark:border-neutral-700"}`}>
         🎤
       </button>
+      <button onClick={() => setOpenPlates(true)} title="Plate calculator" className="h-10 px-3 rounded-lg border border-neutral-300 dark:border-neutral-700">🥞</button>
       <button
-        onClick={() =>
-          completeSet(exId, setId, {
-            weight: parseFloat(weight) || undefined,
-            reps: parseInt(reps) || undefined,
-            rpe: parseFloat(rpe) || undefined,
-          })
-        }
+        onClick={() => {
+          hapticTap();
+          const wKg = fromUserUnits(parseFloat(weight) || 0, unit);
+          const r = parseInt(reps) || undefined;
+          const rpeNum = parseFloat(rpe) || undefined;
+          completeSet(exId, setId, { weight: isNaN(wKg) ? undefined : wKg, reps: r, rpe: rpeNum });
+        }}
         className="h-10 px-4 rounded-lg bg-black text-white dark:bg-white dark:text-black"
       >
         ✓
       </button>
+
+      <PlateModal
+        open={openPlates}
+        onClose={() => setOpenPlates(false)}
+        initialTarget={parseFloat(weight) || undefined}
+      />
     </div>
   );
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,13 @@
+import { Capacitor } from "@capacitor/core";
+
+export function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI__" in window;
+}
+
+export function isCapacitorNative(): boolean {
+  try {
+    return Capacitor?.isNativePlatform?.() ?? false;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -1,0 +1,15 @@
+import { Capacitor } from "@capacitor/core";
+import { Haptics, ImpactStyle, NotificationType } from "@capacitor/haptics";
+
+export async function hapticTap() {
+  if (!Capacitor.isNativePlatform()) return;
+  try { await Haptics.impact({ style: ImpactStyle.Light }); } catch {}
+}
+export async function hapticSuccess() {
+  if (!Capacitor.isNativePlatform()) return;
+  try { await Haptics.notification({ type: NotificationType.Success }); } catch {}
+}
+export async function hapticError() {
+  if (!Capacitor.isNativePlatform()) return;
+  try { await Haptics.notification({ type: NotificationType.Error }); } catch {}
+}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,21 @@
+export type ThemePref = "system" | "light" | "dark";
+
+function computeDark(pref: ThemePref) {
+  if (pref === "light") return false;
+  if (pref === "dark") return true;
+  return window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
+}
+
+export function applyTheme(pref: ThemePref) {
+  const dark = computeDark(pref);
+  const root = document.documentElement;
+  root.classList.toggle("dark", dark);
+}
+
+export function bindSystemTheme(pref: ThemePref, cb: () => void) {
+  if (pref !== "system") return () => {};
+  const mq = window.matchMedia("(prefers-color-scheme: dark)");
+  const handler = () => cb();
+  mq.addEventListener?.("change", handler);
+  return () => mq.removeEventListener?.("change", handler);
+}

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -1,0 +1,13 @@
+export type Unit = "kg" | "lb";
+const KG_PER_LB = 0.45359237;
+const LB_PER_KG = 1 / KG_PER_LB;
+
+export function toUserUnits(kgValue: number, unit: Unit): number {
+  return unit === "kg" ? kgValue : +(kgValue * LB_PER_KG).toFixed(1);
+}
+export function fromUserUnits(value: number, unit: Unit): number {
+  return unit === "kg" ? value : +(value * KG_PER_LB).toFixed(2);
+}
+export function unitLabel(unit: Unit): "kg" | "lb" {
+  return unit;
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -69,6 +69,22 @@ export default function Settings() {
             className="h-10 rounded-lg border px-3 border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900"
           />
         </label>
+
+        <label className="space-y-1">
+          <div className="text-sm">Default bar weight ({settings.unit})</div>
+          <input
+            type="number"
+            min={settings.unit === "kg" ? 10 : 20}
+            step={settings.unit === "kg" ? 0.5 : 1}
+            value={settings.unit === "kg" ? settings.barWeightKg : Math.round(settings.barWeightKg * 2.20462)}
+            onChange={(e) => {
+              const v = Number(e.target.value || 0);
+              const kg = settings.unit === "kg" ? v : v * 0.45359237;
+              useWorkoutStore.getState().setSetting("barWeightKg", Math.max(5, +kg.toFixed(2)));
+            }}
+            className="h-10 rounded-lg border px-3 border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900"
+          />
+        </label>
       </div>
 
       <div className="space-y-3">

--- a/src/pages/WorkoutDetail.tsx
+++ b/src/pages/WorkoutDetail.tsx
@@ -2,12 +2,14 @@ import { useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useWorkoutStore } from "../store/workout";
 import { est1RM } from "../utils/exerciseLookup";
+import { toUserUnits, unitLabel } from "../lib/units";
 
 export default function WorkoutDetail() {
   const { id } = useParams();
   const nav = useNavigate();
   const history = useWorkoutStore((s) => s.history);
   const repeat = useWorkoutStore((s) => s.repeatFromHistory);
+  const unit = useWorkoutStore((s) => s.settings.unit);
 
   const w = useMemo(() => history.find((x) => x.id === id), [history, id]);
 
@@ -45,9 +47,9 @@ export default function WorkoutDetail() {
               <div key={s.id} className="flex items-center justify-between rounded-lg border px-3 h-11 border-neutral-300 dark:border-neutral-700">
                 <div className="text-sm">Set {i + 1}</div>
                 <div className="text-sm opacity-80">
-                  {s.weight ?? "—"} × {s.reps ?? "—"} {s.rpe ? `• RPE ${s.rpe}` : ""}
+                  {s.weight !== undefined ? `${toUserUnits(s.weight, unit)} ${unitLabel(unit)}` : "—"} × {s.reps ?? "—"} {s.rpe ? `• RPE ${s.rpe}` : ""}
                   {s.weight && s.reps ? (
-                    <span className="ml-2 text-xs opacity-70">1RM≈ {est1RM(s.weight, s.reps)}</span>
+                    <span className="ml-2 text-xs opacity-70">1RM≈ {toUserUnits(est1RM(s.weight, s.reps)!, unit)} {unitLabel(unit)}</span>
                   ) : null}
                 </div>
               </div>

--- a/src/store/workout.ts
+++ b/src/store/workout.ts
@@ -38,6 +38,7 @@ type Settings = {
   unit: "kg" | "lb";
   theme: "system" | "light" | "dark";
   defaultRestSec: number;
+  barWeightKg: number;
 };
 
 type ExportShape = {
@@ -90,7 +91,7 @@ export const useWorkoutStore = create<State>()(
       templates: [],
       favorites: [],
       recents: [],
-      settings: { unit: "kg", theme: "system", defaultRestSec: 90 },
+      settings: { unit: "kg", theme: "system", defaultRestSec: 90, barWeightKg: 20 },
 
       ensureActive: () => {
         if (!get().activeWorkout) {
@@ -214,7 +215,7 @@ export const useWorkoutStore = create<State>()(
             templates: Array.isArray(data.templates) ? data.templates : [],
             favorites: Array.isArray(data.favorites) ? data.favorites : [],
             recents: [],
-            settings: { unit: "kg", theme: "system", defaultRestSec: 90, ...(data.settings ?? {}) },
+            settings: { unit: "kg", theme: "system", defaultRestSec: 90, barWeightKg: 20, ...(data.settings ?? {}) },
           });
           return true;
         } catch {
@@ -229,14 +230,24 @@ export const useWorkoutStore = create<State>()(
           templates: [],
           favorites: [],
           recents: [],
-          settings: { unit: "kg", theme: "system", defaultRestSec: 90 },
+          settings: { unit: "kg", theme: "system", defaultRestSec: 90, barWeightKg: 20 },
         });
       },
     }),
     {
       name: "liftlegends-v1",
-      version: 2,
+      version: 3,
       storage: createJSONStorage(() => localStorage),
+      migrate: (state: any, fromVersion: number) => {
+        if (fromVersion < 3) {
+          const s = state?.state ?? state;
+          if (s && s.settings && typeof s.settings.barWeightKg === "undefined") {
+            s.settings.barWeightKg = 20;
+          }
+          return state;
+        }
+        return state;
+      },
     }
   )
 );

--- a/src/targets/tauri/Titlebar.tsx
+++ b/src/targets/tauri/Titlebar.tsx
@@ -1,0 +1,34 @@
+import { appWindow } from "@tauri-apps/api/window";
+
+export default function Titlebar() {
+  return (
+    <div
+      data-tauri-drag-region
+      className="fixed top-0 inset-x-0 z-50 h-8 flex items-center justify-between px-2
+                 bg-white/80 dark:bg-neutral-900/80 backdrop-blur border-b
+                 border-neutral-200 dark:border-neutral-800"
+    >
+      <div data-tauri-drag-region className="text-xs opacity-70">Lift Legends</div>
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => appWindow.minimize()}
+          className="h-6 w-8 rounded hover:bg-neutral-200/60 dark:hover:bg-neutral-800/60"
+          title="Minimize"
+        >—</button>
+        <button
+          onClick={async () => {
+            const isMax = await appWindow.isMaximized();
+            isMax ? appWindow.unmaximize() : appWindow.maximize();
+          }}
+          className="h-6 w-8 rounded hover:bg-neutral-200/60 dark:hover:bg-neutral-800/60"
+          title="Maximize"
+        >▢</button>
+        <button
+          onClick={() => appWindow.close()}
+          className="h-6 w-8 rounded hover:bg-red-500/20"
+          title="Close"
+        >×</button>
+      </div>
+    </div>
+  );
+}

--- a/src/utils/plates.ts
+++ b/src/utils/plates.ts
@@ -1,0 +1,16 @@
+export type PlatePlan = { perSide: number[]; remainder: number };
+
+export function planPlates(totalKg: number, barKg: number, availableKg: number[]): PlatePlan {
+  const perSideTarget = (totalKg - barKg) / 2;
+  if (perSideTarget <= 0) return { perSide: [], remainder: perSideTarget };
+  const plates = [...availableKg].sort((a, b) => b - a);
+  const out: number[] = [];
+  let rem = perSideTarget;
+  for (const p of plates) {
+    while (rem >= p - 1e-6) {
+      out.push(p);
+      rem = +(rem - p).toFixed(3);
+    }
+  }
+  return { perSide: out, remainder: +rem.toFixed(3) };
+}


### PR DESCRIPTION
## Summary
- detect platform (Tauri vs Capacitor)
- custom Tauri titlebar & decorations disabled
- mobile haptics hooks
- live theme sync with system dark mode
- unit conversion & plate calculator with bar weight setting

## Testing
- `npm run build`
- `git push -u origin feat/platform-polish-theme-units-plates` *(failed: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ae16987b9083259b14cea4c5021fc5