### PR TITLE
feat: integrate SQLite exercise DB with info modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.2",
+        "sql.js": "^1.13.0",
         "zustand": "^5.0.8"
       },
       "devDependencies": {
@@ -3023,6 +3024,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sql.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.13.0.tgz",
+      "integrity": "sha512-RJbVP1HRDlUUXahJ7VMTcu9Rm1Nzw+EBpoPr94vnbD4LwR715F3CcxE2G2k45PewcaZ57pjetYa+LoSJLAASgA==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.2",
+    "sql.js": "^1.13.0",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/src/components/ExerciseInfoModal.tsx
+++ b/src/components/ExerciseInfoModal.tsx
@@ -1,0 +1,23 @@
+import Modal from "./Modal";
+import type { DbExercise } from "../data/exercisesDb";
+
+export default function ExerciseInfoModal({
+  open, onClose, exercise,
+}: { open: boolean; onClose: () => void; exercise?: DbExercise | null }) {
+  if (!open || !exercise) return null;
+  return (
+    <Modal open={open} onClose={onClose} title={exercise.name}>
+      <div className="space-y-3">
+        <div className="text-sm opacity-70">
+          {exercise.primary} • {exercise.equipment.join(", ") || "No equipment"}
+        </div>
+        <div className="whitespace-pre-wrap leading-relaxed">
+          {exercise.description || "No description available."}
+        </div>
+        <div className="flex justify-end">
+          <button onClick={onClose} className="h-10 px-4 rounded-lg bg-black text-white dark:bg-white dark:text-black">Close</button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/data/exercisesDb.ts
+++ b/src/data/exercisesDb.ts
@@ -1,0 +1,140 @@
+import initSqlJs from "sql.js";
+// Vite resolves ?url to a proper asset path for the wasm file
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import wasmUrl from "sql.js/dist/sql-wasm.wasm?url";
+
+export type DbExercise = {
+  id: string;
+  name: string;
+  primary: string;
+  equipment: string[];
+  description?: string;
+  tags?: string[];
+};
+
+let _cache: DbExercise[] | null = null;
+let _loading: Promise<DbExercise[]> | null = null;
+
+function normalizeRow(row: Record<string, any>): DbExercise {
+  const equipmentRaw = row.equipment ?? row.equipments ?? row.equipment_list ?? "";
+  const tagsRaw = row.tags ?? row.tag_list ?? "";
+
+  const equipment =
+    Array.isArray(equipmentRaw)
+      ? equipmentRaw
+      : String(equipmentRaw || "")
+          .split(/[,/]/)
+          .map((s) => s.trim())
+          .filter(Boolean);
+
+  const tags =
+    Array.isArray(tagsRaw)
+      ? tagsRaw
+      : String(tagsRaw || "")
+          .split(/[,/]/)
+          .map((s) => s.trim())
+          .filter(Boolean);
+
+  return {
+    id: String(row.id ?? row.slug ?? row.name),
+    name: String(row.name),
+    primary: String(row.primary ?? row.primary_muscle ?? row.muscle ?? "Other"),
+    equipment,
+    description: row.description ?? row.instructions ?? row.notes ?? undefined,
+    tags,
+  };
+}
+
+async function queryAll(sql: any, dbBytes: Uint8Array, q: string): Promise<Record<string, any>[]> {
+  const SQL = await initSqlJs({ locateFile: () => wasmUrl });
+  const db = new SQL.Database(dbBytes);
+  try {
+    const res = db.exec(q);
+    if (!res || !res[0]) return [];
+    const cols = res[0].columns;
+    return res[0].values.map((arr: any[]) => {
+      const o: Record<string, any> = {};
+      arr.forEach((v, i) => (o[cols[i]] = v));
+      return o;
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/** Attempts multiple common schemas to find exercises */
+async function bestEffortRead(dbBytes: Uint8Array): Promise<DbExercise[]> {
+  const candidates = [
+    // most likely
+    `SELECT id, name, primary_muscle AS primary, equipment, description, tags FROM exercises`,
+    `SELECT id, name, muscle AS primary, equipment, description, tags FROM exercises`,
+    `SELECT id, name, primary AS primary, equipment, description, tags FROM exercises`,
+    // other table names
+    `SELECT id, name, muscle AS primary, equipment, instructions AS description, tags FROM exercise`,
+    `SELECT id, name, primary_muscle AS primary, equipment_list AS equipment, instructions AS description FROM exercise_library`,
+    // very generic fallback: pick any table that has name+description
+    `SELECT name, description FROM exercises`,
+  ];
+
+  for (const q of candidates) {
+    try {
+      const rows = await queryAll(null, dbBytes, q);
+      if (rows.length) {
+        return rows
+          .filter((r) => r.name)
+          .map(normalizeRow)
+          .sort((a, b) => a.name.localeCompare(b.name));
+      }
+    } catch {
+      // try next
+    }
+  }
+
+  // one last fallback: introspect sqlite_master and try first table
+  const SQL = await initSqlJs({ locateFile: () => wasmUrl });
+  const db = new SQL.Database(dbBytes);
+  try {
+    const master = db.exec(`SELECT name FROM sqlite_master WHERE type='table' ORDER BY name LIMIT 1`);
+    if (master[0]?.values?.[0]?.[0]) {
+      const table = master[0].values[0][0] as string;
+      const rows = db.exec(`SELECT * FROM ${table} LIMIT 1000`);
+      if (rows[0]) {
+        const cols = rows[0].columns;
+        const nameIdx = cols.findIndex((c) => /name/i.test(c));
+        if (nameIdx >= 0) {
+          return rows[0].values
+            .map((arr: any[]) => {
+              const obj: Record<string, any> = {};
+              arr.forEach((v, i) => (obj[cols[i]] = v));
+              return obj;
+            })
+            .filter((r) => r.name)
+            .map(normalizeRow);
+        }
+      }
+    }
+  } finally {
+    db.close();
+  }
+
+  return [];
+}
+
+/** Public loader (cached). Fetches /workout_exercises.db and reads rows. */
+export async function loadDbExercises(): Promise<DbExercise[]> {
+  if (_cache) return _cache;
+  if (_loading) return _loading;
+
+  _loading = (async () => {
+    const resp = await fetch("/workout_exercises.db");
+    if (!resp.ok) throw new Error("Failed to fetch workout_exercises.db");
+    const buf = new Uint8Array(await resp.arrayBuffer());
+    const list = await bestEffortRead(buf);
+    _cache = list;
+    return list;
+  })();
+
+  return _loading;
+}
+

--- a/src/hooks/useDbExercises.ts
+++ b/src/hooks/useDbExercises.ts
@@ -1,0 +1,29 @@
+import { useEffect, useMemo, useState } from "react";
+import Fuse from "fuse.js";
+import { DbExercise, loadDbExercises } from "../data/exercisesDb";
+
+export function useDbExercises() {
+  const [data, setData] = useState<DbExercise[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    loadDbExercises()
+      .then((list) => { if (alive) setData(list); })
+      .catch((e) => { if (alive) setError(String(e?.message || e)); })
+      .finally(() => { if (alive) setLoading(false); });
+    return () => { alive = false; };
+  }, []);
+
+  const fuse = useMemo(() => {
+    if (!data) return null;
+    return new Fuse(data, {
+      keys: [{ name: "name", weight: 0.7 }, { name: "primary", weight: 0.2 }, { name: "tags", weight: 0.1 }],
+      threshold: 0.36,
+      ignoreLocation: true,
+    });
+  }, [data]);
+
+  return { data, error, loading, fuse };
+}

--- a/src/pages/Exercises.tsx
+++ b/src/pages/Exercises.tsx
@@ -1,13 +1,88 @@
+import { useMemo, useState } from "react";
+import { useWorkoutStore } from "../store/workout";
+import { useDbExercises } from "../hooks/useDbExercises";
+import ExerciseInfoModal from "../components/ExerciseInfoModal";
+
 export default function Exercises() {
+  const ensure = useWorkoutStore((s) => s.ensureActive);
+  const addExercise = useWorkoutStore((s) => s.addExercise);
+  const favorites = useWorkoutStore((s) => s.favorites);
+  const toggleFav = useWorkoutStore((s) => s.toggleFavoriteExercise);
+
+  const { data, loading, error, fuse } = useDbExercises();
+
+  const [q, setQ] = useState("");
+  const [muscle, setMuscle] = useState<string>("All");
+  const [show, setShow] = useState(false);
+  const [selected, setSelected] = useState<any>(null);
+
+  const muscles = useMemo(() => {
+    const set = new Set<string>();
+    data?.forEach((e) => set.add(e.primary));
+    return ["All", ...Array.from(set).sort()];
+  }, [data]);
+
+  const list = useMemo(() => {
+    if (!data) return [];
+    const base = muscle === "All" ? data : data.filter((e) => e.primary === muscle);
+    if (!q.trim()) return base.slice(0, 400);
+    if (fuse) return fuse.search(q).map((r) => r.item).filter((e) => muscle === "All" || e.primary === muscle);
+    return base.filter((e) => e.name.toLowerCase().includes(q.toLowerCase()));
+  }, [data, fuse, q, muscle]);
+
   return (
-    <div className="space-y-3">
-      <input
-        placeholder="Search exercises..."
-        className="w-full h-11 rounded-xl px-3 border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900"
-      />
-      <div className="rounded-2xl border border-neutral-200 dark:border-neutral-800 p-4">
-        <div className="text-sm opacity-70">Exercise library coming soon.</div>
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2">
+        <input
+          placeholder="Search exercises..."
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          className="w-full md:w-80 h-11 rounded-xl px-3 border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900"
+        />
+        <div className="flex gap-2 flex-wrap">
+          {muscles.map((m) => (
+            <button key={m} onClick={() => setMuscle(m)}
+              className={`h-11 px-3 rounded-xl border ${muscle===m ? "bg-neutral-100 dark:bg-neutral-800" : "border-neutral-300 dark:border-neutral-700"}`}>
+              {m}
+            </button>
+          ))}
+        </div>
       </div>
+
+      {loading && <div className="text-sm opacity-70">Loading exercise database…</div>}
+      {error && <div className="text-sm text-red-600">Failed to load DB: {error}</div>}
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        {list.map((e) => {
+          const isFav = favorites.includes(e.name);
+          return (
+            <div key={e.id} className="rounded-2xl border border-neutral-200 dark:border-neutral-800 p-4">
+              <div className="flex items-center justify-between gap-2 mb-1">
+                <div className="min-w-0">
+                  <div className="font-medium truncate">{e.name}</div>
+                  <div className="text-xs opacity-70 truncate">{e.primary} • {e.equipment.join(", ") || "No equipment"}</div>
+                </div>
+                <div className="flex gap-2 shrink-0">
+                  <button title="Info" onClick={() => { setSelected(e); setShow(true); }}
+                    className="h-9 w-9 rounded-lg border border-neutral-300 dark:border-neutral-700">?</button>
+                  <button title={isFav ? "Unfavorite" : "Favorite"} onClick={() => toggleFav(e.name)}
+                    className={`h-9 w-9 rounded-lg border ${isFav ? "bg-yellow-100 dark:bg-yellow-900/30" : "border-neutral-300 dark:border-neutral-700"}`}>★</button>
+                  <button
+                    onClick={() => { ensure(); addExercise(e.name); }}
+                    className="h-9 px-3 rounded-lg bg-black text-white dark:bg-white dark:text-black"
+                  >
+                    Add
+                  </button>
+                </div>
+              </div>
+              {e.description && <div className="text-xs opacity-70 line-clamp-2">{e.description}</div>}
+            </div>
+          );
+        })}
+        {list.length === 0 && !loading && <div className="opacity-70 text-sm">No matches.</div>}
+      </div>
+
+      <ExerciseInfoModal open={show} onClose={() => setShow(false)} exercise={selected} />
     </div>
   );
 }

--- a/src/pages/Workouts.tsx
+++ b/src/pages/Workouts.tsx
@@ -1,14 +1,20 @@
 import { Link } from "react-router-dom";
+import { useState } from "react";
 import { useWorkoutStore } from "../store/workout";
 import SetRow from "../components/SetRow";
 import RestTimerChip from "../components/RestTimerChip";
 import CoachPanel from "../components/CoachPanel";
+import { useDbExercises } from "../hooks/useDbExercises";
+import ExerciseInfoModal from "../components/ExerciseInfoModal";
 
 export default function Workouts() {
   const active = useWorkoutStore((s) => s.activeWorkout);
   const addSet = useWorkoutStore((s) => s.addSet);
   const history = useWorkoutStore((s) => s.history);
   const repeat = useWorkoutStore((s) => s.repeatFromHistory);
+  const { data } = useDbExercises();
+  const [showInfo, setShowInfo] = useState(false);
+  const [selected, setSelected] = useState<any>(null);
 
   return (
     <div className="grid md:grid-cols-[1fr_320px] gap-6">
@@ -23,7 +29,18 @@ export default function Workouts() {
             {active.exercises.map((ex) => (
               <div key={ex.id} className="rounded-2xl border border-neutral-200 dark:border-neutral-800 p-4">
                 <div className="mb-3 flex items-center justify-between">
-                  <div className="font-semibold">{ex.name}</div>
+                  <div className="flex items-center gap-2">
+                    <div className="font-semibold">{ex.name}</div>
+                    <button
+                      title="Exercise info"
+                      onClick={() => {
+                        const match = data?.find((d) => d.name.toLowerCase() === ex.name.toLowerCase());
+                        setSelected(match ?? { name: ex.name, primary: "—", equipment: [], description: "No description found." });
+                        setShowInfo(true);
+                      }}
+                      className="h-7 w-7 rounded-md border border-neutral-300 dark:border-neutral-700 text-sm"
+                    >?</button>
+                  </div>
                   {ex.sets.length > 0 && ex.sets[ex.sets.length - 1].restEndAt ? (
                     <RestTimerChip endAt={ex.sets[ex.sets.length - 1].restEndAt!} />
                   ) : null}
@@ -67,6 +84,7 @@ export default function Workouts() {
       <div className="hidden md:block">
         <CoachPanel />
       </div>
+      <ExerciseInfoModal open={showInfo} onClose={() => setShowInfo(false)} exercise={selected} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- load exercises from `workout_exercises.db` via sql.js and cache results
- add searchable exercise picker and modal for exercise details
- show info buttons for exercises on workout and picker screens

## Testing
- `npm run build`
- `git push -u origin feat/exercises-from-sqlite-and-info-modal` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1bab2cf48325b2c2b390f274fa44