### PR TITLE
feat: db lazy load, muscle tags, PR tracking, sync stub, media scaffolding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Titlebar from "./targets/tauri/Titlebar";
 import { applyTheme, bindSystemTheme } from "./lib/theme";
 import { useDbExercises } from "./hooks/useDbExercises";
 import ExerciseInfoModal from "./components/ExerciseInfoModal";
+import { warmLoadDbExercisesIdle } from "./data/exercisesDb";
 
 function ExercisePicker({ onPicked }: { onPicked: (name: string) => void }) {
   const { data, loading, error, fuse } = useDbExercises();
@@ -78,6 +79,10 @@ export default function App() {
     const off = bindSystemTheme(theme, () => applyTheme(theme));
     return off;
   }, [theme]);
+
+  useEffect(() => {
+    warmLoadDbExercisesIdle();
+  }, []);
 
   return (
     <>

--- a/src/components/ExerciseInfoModal.tsx
+++ b/src/components/ExerciseInfoModal.tsx
@@ -5,12 +5,32 @@ export default function ExerciseInfoModal({
   open, onClose, exercise,
 }: { open: boolean; onClose: () => void; exercise?: DbExercise | null }) {
   if (!open || !exercise) return null;
+  const hasMedia = !!(exercise.gifUrl || exercise.imageUrl || (exercise.images && exercise.images.length));
   return (
     <Modal open={open} onClose={onClose} title={exercise.name}>
       <div className="space-y-3">
         <div className="text-sm opacity-70">
           {exercise.primary} • {exercise.equipment.join(", ") || "No equipment"}
         </div>
+
+        {hasMedia && (
+          <div className="rounded-xl border border-neutral-200 dark:border-neutral-800 p-2">
+            {/* MEDIA PLACEHOLDER — safe if URLs are missing. Add actual <img> or <video> when data is ready. */}
+            {exercise.gifUrl && (
+              <div className="rounded-lg overflow-hidden">
+                {/* Future: <img src={exercise.gifUrl} alt={`${exercise.name} demo`} className="w-full h-auto" /> */}
+                <div className="text-xs opacity-70 p-2">GIF available (hidden until integrated): {exercise.gifUrl}</div>
+              </div>
+            )}
+            {!exercise.gifUrl && exercise.imageUrl && (
+              <div className="rounded-lg overflow-hidden">
+                {/* Future: <img src={exercise.imageUrl} alt={`${exercise.name} image`} className="w-full h-auto" /> */}
+                <div className="text-xs opacity-70 p-2">Image available (hidden until integrated): {exercise.imageUrl}</div>
+              </div>
+            )}
+          </div>
+        )}
+
         <div className="whitespace-pre-wrap leading-relaxed">
           {exercise.description || "No description available."}
         </div>

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -5,6 +5,7 @@ const items = [
   { to: "/workouts", label: "Workouts" },
   { to: "/templates", label: "Templates" },
   { to: "/exercises", label: "Exercises" },
+  { to: "/prs", label: "PRs" },
   { to: "/settings", label: "Settings" },
 ];
 

--- a/src/components/Sparkline.tsx
+++ b/src/components/Sparkline.tsx
@@ -1,0 +1,26 @@
+export default function Sparkline({ points, width = 240, height = 64, strokeWidth = 2 }: {
+  points: Array<{ t: number; v: number }>;
+  width?: number;
+  height?: number;
+  strokeWidth?: number;
+}) {
+  if (points.length === 0) return <div className="text-xs opacity-70">No data</div>;
+  const xs = points.map((p) => p.t);
+  const ys = points.map((p) => p.v);
+  const minX = Math.min(...xs), maxX = Math.max(...xs);
+  const minY = Math.min(...ys), maxY = Math.max(...ys);
+  const dx = maxX - minX || 1;
+  const dy = maxY - minY || 1;
+  const path = points
+    .map((p, i) => {
+      const x = ((p.t - minX) / dx) * (width - 8) + 4;
+      const y = height - (((p.v - minY) / dy) * (height - 8) + 4);
+      return `${i === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+      <path d={path} fill="none" stroke="currentColor" strokeWidth={strokeWidth} />
+    </svg>
+  );
+}

--- a/src/components/TabsNav.tsx
+++ b/src/components/TabsNav.tsx
@@ -5,13 +5,14 @@ const tabs = [
   { to: "/workouts", label: "Workouts" },
   { to: "/templates", label: "Templates" },
   { to: "/exercises", label: "Exercises" },
+  { to: "/prs", label: "PRs" },
   { to: "/settings", label: "Settings" },
 ];
 
 export default function TabsNav() {
   return (
     <nav className="border-t border-neutral-200 dark:border-neutral-800 bg-white/80 dark:bg-neutral-900/80 backdrop-blur">
-      <ul className="mx-auto grid max-w-3xl grid-cols-5">
+      <ul className="mx-auto grid max-w-3xl grid-cols-6">
         {tabs.map((t) => (
           <li key={t.to} className="text-center">
             <NavLink

--- a/src/lib/muscle.ts
+++ b/src/lib/muscle.ts
@@ -1,0 +1,14 @@
+export const MUSCLE_META: Record<string, { label: string; color: string; icon: string }> = {
+  Chest:     { label: "Chest",     color: "#ef4444", icon: "⬤" },
+  Back:      { label: "Back",      color: "#3b82f6", icon: "⬤" },
+  Shoulders: { label: "Shoulders", color: "#f59e0b", icon: "⬤" },
+  Legs:      { label: "Legs",      color: "#22c55e", icon: "⬤" },
+  Arms:      { label: "Arms",      color: "#a855f7", icon: "⬤" },
+  Core:      { label: "Core",      color: "#14b8a6", icon: "⬤" },
+  Other:     { label: "Other",     color: "#9ca3af", icon: "⬤" },
+};
+
+export function muscleMeta(name?: string) {
+  if (!name) return MUSCLE_META.Other;
+  return MUSCLE_META[name] ?? { ...MUSCLE_META.Other, label: name };
+}

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -1,0 +1,29 @@
+export async function uploadBackup(url: string, key: string, payloadJson: string): Promise<{ ok: boolean; msg: string }> {
+  if (!url) return { ok: false, msg: "Sync URL is empty" };
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-sync-key": key ?? "" },
+      body: payloadJson,
+    });
+    if (!res.ok) return { ok: false, msg: `HTTP ${res.status}` };
+    return { ok: true, msg: "Uploaded" };
+  } catch (e: any) {
+    return { ok: false, msg: e?.message || "Network error" };
+  }
+}
+
+export async function downloadBackup(url: string, key: string): Promise<{ ok: boolean; msg: string; json?: string }> {
+  if (!url) return { ok: false, msg: "Sync URL is empty" };
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: { "x-sync-key": key ?? "" },
+    });
+    if (!res.ok) return { ok: false, msg: `HTTP ${res.status}` };
+    const text = await res.text();
+    return { ok: true, msg: "Downloaded", json: text };
+  } catch (e: any) {
+    return { ok: false, msg: e?.message || "Network error" };
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import Workouts from "./pages/Workouts";
 import WorkoutDetail from "./pages/WorkoutDetail";
 import Templates from "./pages/Templates";
 import Exercises from "./pages/Exercises";
+import PRs from "./pages/PRs";
 import Settings from "./pages/Settings";
 import NotFound from "./pages/NotFound";
 
@@ -21,6 +22,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           <Route path="workouts/:id" element={<WorkoutDetail />} />
           <Route path="templates" element={<Templates />} />
           <Route path="exercises" element={<Exercises />} />
+          <Route path="prs" element={<PRs />} />
           <Route path="settings" element={<Settings />} />
           <Route path="*" element={<NotFound />} />
         </Route>

--- a/src/pages/Exercises.tsx
+++ b/src/pages/Exercises.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { useWorkoutStore } from "../store/workout";
 import { useDbExercises } from "../hooks/useDbExercises";
 import ExerciseInfoModal from "../components/ExerciseInfoModal";
+import { muscleMeta } from "../lib/muscle";
 
 export default function Exercises() {
   const ensure = useWorkoutStore((s) => s.ensureActive);
@@ -13,6 +14,7 @@ export default function Exercises() {
 
   const [q, setQ] = useState("");
   const [muscle, setMuscle] = useState<string>("All");
+  const [activeTags, setActiveTags] = useState<string[]>([]);
   const [show, setShow] = useState(false);
   const [selected, setSelected] = useState<any>(null);
 
@@ -22,13 +24,29 @@ export default function Exercises() {
     return ["All", ...Array.from(set).sort()];
   }, [data]);
 
+  const tagList = useMemo(() => {
+    if (!data) return [];
+    const cnt = new Map<string, number>();
+    for (const e of data) {
+      (e.tags ?? []).forEach((t) => cnt.set(t, (cnt.get(t) ?? 0) + 1));
+    }
+    return Array.from(cnt.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 20)
+      .map(([t]) => t);
+  }, [data]);
+
   const list = useMemo(() => {
     if (!data) return [];
     const base = muscle === "All" ? data : data.filter((e) => e.primary === muscle);
-    if (!q.trim()) return base.slice(0, 400);
-    if (fuse) return fuse.search(q).map((r) => r.item).filter((e) => muscle === "All" || e.primary === muscle);
-    return base.filter((e) => e.name.toLowerCase().includes(q.toLowerCase()));
-  }, [data, fuse, q, muscle]);
+    const withTags = activeTags.length === 0 ? base : base.filter((e) => {
+      const set = new Set(e.tags ?? []);
+      return activeTags.every((t) => set.has(t));
+    });
+    if (!q.trim()) return withTags.slice(0, 400);
+    if (fuse) return fuse.search(q).map((r) => r.item).filter((e) => withTags.includes(e));
+    return withTags.filter((e) => e.name.toLowerCase().includes(q.toLowerCase()));
+  }, [data, fuse, q, muscle, activeTags]);
 
   return (
     <div className="space-y-4">
@@ -41,13 +59,44 @@ export default function Exercises() {
         />
         <div className="flex gap-2 flex-wrap">
           {muscles.map((m) => (
-            <button key={m} onClick={() => setMuscle(m)}
-              className={`h-11 px-3 rounded-xl border ${muscle===m ? "bg-neutral-100 dark:bg-neutral-800" : "border-neutral-300 dark:border-neutral-700"}`}>
-              {m}
+            <button
+              key={m}
+              onClick={() => setMuscle(m)}
+              className={`h-11 px-3 rounded-xl border ${muscle===m ? "bg-neutral-100 dark:bg-neutral-800" : "border-neutral-300 dark:border-neutral-700"}`}
+            >
+              <span className="inline-flex items-center gap-2">
+                <span
+                  className="inline-block h-2.5 w-2.5 rounded-full"
+                  style={{ backgroundColor: m === "All" ? "#9ca3af" : muscleMeta(m).color }}
+                />
+                {m}
+              </span>
             </button>
           ))}
         </div>
       </div>
+
+      {tagList.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {tagList.map((t) => {
+            const on = activeTags.includes(t);
+            return (
+              <button
+                key={t}
+                onClick={() => setActiveTags(on ? activeTags.filter(x => x !== t) : [...activeTags, t])}
+                className={`h-8 px-3 rounded-full border text-sm ${on ? "bg-neutral-100 dark:bg-neutral-800" : "border-neutral-300 dark:border-neutral-700"}`}
+              >
+                #{t}
+              </button>
+            );
+          })}
+          {activeTags.length > 0 && (
+            <button onClick={() => setActiveTags([])} className="h-8 px-3 rounded-full border border-neutral-300 dark:border-neutral-700 text-sm">
+              Clear tags
+            </button>
+          )}
+        </div>
+      )}
 
       {loading && <div className="text-sm opacity-70">Loading exercise database…</div>}
       {error && <div className="text-sm text-red-600">Failed to load DB: {error}</div>}
@@ -60,7 +109,16 @@ export default function Exercises() {
               <div className="flex items-center justify-between gap-2 mb-1">
                 <div className="min-w-0">
                   <div className="font-medium truncate">{e.name}</div>
-                  <div className="text-xs opacity-70 truncate">{e.primary} • {e.equipment.join(", ") || "No equipment"}</div>
+                  <div className="text-xs opacity-80 flex items-center gap-2">
+                    <span className="inline-flex items-center gap-1">
+                      <span
+                        className="inline-block h-2.5 w-2.5 rounded-full"
+                        style={{ backgroundColor: muscleMeta(e.primary).color }}
+                      />
+                      {e.primary}
+                    </span>
+                    • {e.equipment.join(", ") || "No equipment"}
+                  </div>
                 </div>
                 <div className="flex gap-2 shrink-0">
                   <button title="Info" onClick={() => { setSelected(e); setShow(true); }}

--- a/src/pages/PRs.tsx
+++ b/src/pages/PRs.tsx
@@ -1,0 +1,62 @@
+import { useMemo, useState } from "react";
+import { useWorkoutStore } from "../store/workout";
+import { exerciseHistory1RM, personalRecord, recentPRs } from "../utils/prs";
+import Sparkline from "../components/Sparkline";
+
+export default function PRs() {
+  const history = useWorkoutStore((s) => s.history);
+  const [q, setQ] = useState("");
+
+  const exercisesInHistory = useMemo(() => {
+    const set = new Set<string>();
+    history.forEach((w) => w.exercises.forEach((e) => set.add(e.name)));
+    return Array.from(set).sort();
+  }, [history]);
+
+  const selected = q || exercisesInHistory[0] || "";
+  const series = useMemo(() => (selected ? exerciseHistory1RM(history, selected) : []), [history, selected]);
+  const pr = useMemo(() => (selected ? personalRecord(history, selected) : null), [history, selected]);
+  const recent = useMemo(() => recentPRs(history, 30).slice(0, 6), [history]);
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-2xl border border-neutral-200 dark:border-neutral-800 p-4 space-y-3">
+        <div className="text-lg font-semibold">PR Trends</div>
+        <div className="flex flex-wrap items-center gap-2">
+          <input list="ex-list" placeholder="Search exercise..." value={q} onChange={(e) => setQ(e.target.value)}
+            className="h-10 rounded-lg border px-3 border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 w-full sm:w-80" />
+          <datalist id="ex-list">
+            {exercisesInHistory.map((n) => <option key={n} value={n} />)}
+          </datalist>
+        </div>
+        <div className="rounded-xl border border-neutral-200 dark:border-neutral-800 p-3">
+          <div className="mb-2 font-medium">{selected || "No selection"}</div>
+          <Sparkline points={series} />
+          {pr && (
+            <div className="text-sm opacity-80 mt-2">
+              PR: {pr.v.toFixed(1)} (est. 1RM) on {new Date(pr.t).toLocaleDateString()}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-neutral-200 dark:border-neutral-800 p-4">
+        <div className="mb-3 text-lg font-semibold">Recent PR highlights (30d)</div>
+        {recent.length === 0 ? (
+          <div className="text-sm opacity-70">No PRs in the last 30 days.</div>
+        ) : (
+          <ul className="grid sm:grid-cols-2 gap-3">
+            {recent.map((r, i) => (
+              <li key={i} className="rounded-xl border border-neutral-200 dark:border-neutral-800 p-3">
+                <div className="font-medium">{r.name}</div>
+                <div className="text-sm opacity-80">
+                  {r.pr?.v.toFixed(1)} on {r.pr ? new Date(r.pr.t).toLocaleDateString() : "—"}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import { useWorkoutStore } from "../store/workout";
+import { uploadBackup, downloadBackup } from "../lib/sync";
 
 export default function Settings() {
   const settings = useWorkoutStore((s) => s.settings);
@@ -105,13 +106,65 @@ export default function Settings() {
             className="hidden"
             onChange={(e) => { const f = e.target.files?.[0]; if (f) onImportFile(f); e.currentTarget.value = ""; }}
           />
-        </div>
-        {msg && <div className="text-sm opacity-80">{msg}</div>}
       </div>
+      {msg && <div className="text-sm opacity-80">{msg}</div>}
+    </div>
 
+    <div className="space-y-3">
+      <div className="text-lg font-semibold">Cloud Sync (stub)</div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="space-y-1">
+          <div className="text-sm">Sync URL</div>
+          <input
+            value={settings.syncUrl || ""}
+            onChange={(e) => setSetting("syncUrl", e.target.value)}
+            placeholder="https://example.com/liftlegends/backup.json"
+            className="h-10 rounded-lg border px-3 border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900"
+          />
+        </label>
+        <label className="space-y-1">
+          <div className="text-sm">Sync Key (optional)</div>
+          <input
+            value={settings.syncKey || ""}
+            onChange={(e) => setSetting("syncKey", e.target.value)}
+            placeholder="your-secret-key"
+            className="h-10 rounded-lg border px-3 border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900"
+          />
+        </label>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={async () => {
+            const res = await uploadBackup(settings.syncUrl || "", settings.syncKey || "", exportAll());
+            setMsg(res.msg);
+          }}
+          className="h-10 px-4 rounded-lg border border-neutral-300 dark:border-neutral-700"
+        >
+          Upload to URL
+        </button>
+        <button
+          onClick={async () => {
+            const res = await downloadBackup(settings.syncUrl || "", settings.syncKey || "");
+            if (res.ok && res.json) {
+              const ok = importAll(res.json);
+              setMsg(ok ? "Downloaded and merged." : "Downloaded but invalid JSON.");
+            } else {
+              setMsg(res.msg);
+            }
+          }}
+          className="h-10 px-4 rounded-lg border border-neutral-300 dark:border-neutral-700"
+        >
+          Download & Merge
+        </button>
+      </div>
       <div className="text-xs opacity-70">
-        Data is stored locally on this device. Export to keep your own backups.
+        Stub: uses GET/POST to your URL with header <code>x-sync-key</code>. Keep this disabled if you don’t control the endpoint.
       </div>
     </div>
+
+    <div className="text-xs opacity-70">
+      Data is stored locally on this device. Export to keep your own backups.
+    </div>
+  </div>
   );
 }

--- a/src/store/workout.ts
+++ b/src/store/workout.ts
@@ -39,6 +39,8 @@ type Settings = {
   theme: "system" | "light" | "dark";
   defaultRestSec: number;
   barWeightKg: number;
+  syncUrl?: string;
+  syncKey?: string;
 };
 
 type ExportShape = {
@@ -91,7 +93,7 @@ export const useWorkoutStore = create<State>()(
       templates: [],
       favorites: [],
       recents: [],
-      settings: { unit: "kg", theme: "system", defaultRestSec: 90, barWeightKg: 20 },
+      settings: { unit: "kg", theme: "system", defaultRestSec: 90, barWeightKg: 20, syncUrl: "", syncKey: "" },
 
       ensureActive: () => {
         if (!get().activeWorkout) {
@@ -215,7 +217,7 @@ export const useWorkoutStore = create<State>()(
             templates: Array.isArray(data.templates) ? data.templates : [],
             favorites: Array.isArray(data.favorites) ? data.favorites : [],
             recents: [],
-            settings: { unit: "kg", theme: "system", defaultRestSec: 90, barWeightKg: 20, ...(data.settings ?? {}) },
+            settings: { unit: "kg", theme: "system", defaultRestSec: 90, barWeightKg: 20, syncUrl: "", syncKey: "", ...(data.settings ?? {}) },
           });
           return true;
         } catch {
@@ -230,21 +232,25 @@ export const useWorkoutStore = create<State>()(
           templates: [],
           favorites: [],
           recents: [],
-          settings: { unit: "kg", theme: "system", defaultRestSec: 90, barWeightKg: 20 },
+          settings: { unit: "kg", theme: "system", defaultRestSec: 90, barWeightKg: 20, syncUrl: "", syncKey: "" },
         });
       },
     }),
     {
       name: "liftlegends-v1",
-      version: 3,
+      version: 4,
       storage: createJSONStorage(() => localStorage),
       migrate: (state: any, fromVersion: number) => {
+        const s = state?.state ?? state;
+        if (!s) return state;
         if (fromVersion < 3) {
-          const s = state?.state ?? state;
-          if (s && s.settings && typeof s.settings.barWeightKg === "undefined") {
-            s.settings.barWeightKg = 20;
+          if (s.settings && typeof s.settings.barWeightKg === "undefined") s.settings.barWeightKg = 20;
+        }
+        if (fromVersion < 4) {
+          if (s.settings) {
+            if (typeof s.settings.syncUrl === "undefined") s.settings.syncUrl = "";
+            if (typeof s.settings.syncKey === "undefined") s.settings.syncKey = "";
           }
-          return state;
         }
         return state;
       },

--- a/src/utils/prs.ts
+++ b/src/utils/prs.ts
@@ -1,0 +1,44 @@
+import { Workout } from "../store/workout";
+
+export function est1RM(weight?: number, reps?: number): number | undefined {
+  if (!weight || !reps) return undefined;
+  return +(weight * (1 + reps / 30)).toFixed(2); // Epley
+}
+
+export function exerciseHistory1RM(history: Workout[], exerciseName: string): Array<{ t: number; v: number }> {
+  const out: Array<{ t: number; v: number }> = [];
+  for (const w of history) {
+    let bestForWorkout = 0;
+    for (const ex of w.exercises) {
+      if (ex.name.toLowerCase() !== exerciseName.toLowerCase()) continue;
+      for (const s of ex.sets) {
+        if (!s.done) continue;
+        const oneRm = est1RM(s.weight, s.reps) ?? 0;
+        if (oneRm > bestForWorkout) bestForWorkout = oneRm;
+      }
+    }
+    if (bestForWorkout > 0) out.push({ t: w.startedAt, v: +bestForWorkout.toFixed(2) });
+  }
+  return out.sort((a, b) => a.t - b.t);
+}
+
+export function personalRecord(history: Workout[], exerciseName: string) {
+  const list = exerciseHistory1RM(history, exerciseName);
+  if (list.length === 0) return null;
+  return list.reduce((m, x) => (x.v > m.v ? x : m), list[0]);
+}
+
+export function recentPRs(history: Workout[], days: number) {
+  const cutoff = Date.now() - days * 86400000;
+  const names = new Set<string>();
+  for (const w of history) w.exercises.forEach((e) => names.add(e.name));
+  const arr: Array<{ name: string; pr?: { t: number; v: number } }> = [];
+  for (const n of names) {
+    const list = exerciseHistory1RM(history, n);
+    const inWindow = list.filter((x) => x.t >= cutoff);
+    if (inWindow.length === 0) continue;
+    const pr = inWindow.reduce((m, x) => (x.v > m.v ? x : m), inWindow[0]);
+    arr.push({ name: n, pr });
+  }
+  return arr.sort((a, b) => (b.pr?.v ?? 0) - (a.pr?.v ?? 0));
+}


### PR DESCRIPTION
## Summary
- move workout_exercises.db to public and lazily fetch DB with idle prefetch
- add muscle color chips and DB-driven tag filters in exercises list
- track 1RM PRs with sparkline trends and new PRs page
- stub cloud sync settings with upload/download hooks
- scaffold exercise info modal for future GIF/image media

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ae211511388325a4dfc3ce8ead14ea