### PR TITLE
feat: PR badges, repeat last set, close-to-PR nudges

### DIFF
--- a/src/components/SetRow.tsx
+++ b/src/components/SetRow.tsx
@@ -1,65 +1,171 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useWorkoutStore } from "../store/workout";
 import { isVoiceSupported, startDictation, parseWeightReps } from "../utils/voice";
-import { fromUserUnits, unitLabel } from "../lib/units";
+import { fromUserUnits, toUserUnits, unitLabel } from "../lib/units";
 import PlateModal from "./PlateModal";
 import { hapticTap } from "../lib/haptics";
+import { lastCompletedSetInActiveByExId, lastCompletedSetInHistory } from "../utils/history";
+import { personalRecord, est1RM } from "../utils/prs";
 
 type Props = { exId: string; setId: string };
 
 export default function SetRow({ exId, setId }: Props) {
   const completeSet = useWorkoutStore((s) => s.completeSet);
+  const active = useWorkoutStore((s) => s.activeWorkout);
+  const history = useWorkoutStore((s) => s.history);
   const unit = useWorkoutStore((s) => s.settings.unit);
+
+  const exercise = useMemo(
+    () => active?.exercises.find((e) => e.id === exId),
+    [active, exId]
+  );
+  const exerciseName = exercise?.name ?? "";
+
   const [weight, setWeight] = useState<string>("");
   const [reps, setReps] = useState<string>("");
   const [rpe, setRpe] = useState<string>("");
   const [listening, setListening] = useState(false);
   const [openPlates, setOpenPlates] = useState(false);
 
+  // PR proximity computation
+  const prValueKg = useMemo(() => personalRecord(history, exerciseName)?.v, [history, exerciseName]);
+  const candidate1RMkg = useMemo(() => {
+    const w = parseFloat(weight);
+    const r = parseInt(reps);
+    if (!w || !r) return undefined;
+    const kg = fromUserUnits(w, unit);
+    return est1RM(kg, r);
+  }, [weight, reps, unit]);
+
+  const prStatus = useMemo(() => {
+    if (!prValueKg || !candidate1RMkg) return { text: "", tone: "none" as const };
+    if (candidate1RMkg >= prValueKg) {
+      return { text: "🚀 PR pace — press ✓ to log!", tone: "pr" as const };
+    }
+    const ratio = candidate1RMkg / prValueKg;
+    if (ratio >= 0.98) {
+      const pct = Math.round((ratio - 1) * 100); // negative but near zero
+      return { text: "🔥 Close to PR (within ~2%)", tone: "close" as const };
+    }
+    return { text: "", tone: "none" as const };
+  }, [candidate1RMkg, prValueKg]);
+
   const onVoice = () => {
     if (!isVoiceSupported()) return alert("Voice input not supported in this browser.");
     setListening(true);
     startDictation((text) => {
       const { weight: w, reps: r } = parseWeightReps(text);
-      if (w) setWeight(String(w));
-      if (r) setReps(String(r));
+      if (typeof w === "number") setWeight(String(w));
+      if (typeof r === "number") setReps(String(r));
     }, () => setListening(false));
   };
 
-  return (
-    <div className="grid grid-cols-[1fr_1fr_1fr_auto_auto_auto] gap-2 items-center">
-      <input inputMode="decimal" placeholder={unitLabel(unit)} value={weight}
-        onChange={(e) => setWeight(e.target.value)}
-        className="h-10 rounded-lg px-3 border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900" />
-      <input inputMode="numeric" placeholder="reps" value={reps}
-        onChange={(e) => setReps(e.target.value)}
-        className="h-10 rounded-lg px-3 border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900" />
-      <input inputMode="decimal" placeholder="RPE" value={rpe}
-        onChange={(e) => setRpe(e.target.value)}
-        className="h-10 rounded-lg px-3 border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900" />
-      <button onClick={onVoice} title="Voice input"
-        className={`h-10 px-3 rounded-lg border ${listening ? "border-green-500" : "border-neutral-300 dark:border-neutral-700"}`}>
-        🎤
-      </button>
-      <button onClick={() => setOpenPlates(true)} title="Plate calculator" className="h-10 px-3 rounded-lg border border-neutral-300 dark:border-neutral-700">🥞</button>
-      <button
-        onClick={() => {
-          hapticTap();
-          const wKg = fromUserUnits(parseFloat(weight) || 0, unit);
-          const r = parseInt(reps) || undefined;
-          const rpeNum = parseFloat(rpe) || undefined;
-          completeSet(exId, setId, { weight: isNaN(wKg) ? undefined : wKg, reps: r, rpe: rpeNum });
-        }}
-        className="h-10 px-4 rounded-lg bg-black text-white dark:bg-white dark:text-black"
-      >
-        ✓
-      </button>
+  const onRepeat = () => {
+    // Prefer last completed in this exercise during current workout; fall back to history
+    const inActive = lastCompletedSetInActiveByExId(active ?? null, exId);
+    const fallback = exerciseName ? lastCompletedSetInHistory(history, exerciseName) : null;
+    const src = inActive ?? fallback;
+    if (!src) return;
+    if (typeof src.weight === "number") setWeight(String(toUserUnits(src.weight, unit)));
+    if (typeof src.reps === "number") setReps(String(src.reps));
+    if (typeof src.rpe === "number") setRpe(String(src.rpe));
+  };
 
-      <PlateModal
-        open={openPlates}
-        onClose={() => setOpenPlates(false)}
-        initialTarget={parseFloat(weight) || undefined}
-      />
+  return (
+    <div className="space-y-1.5">
+      <div className="grid grid-cols-[1fr_1fr_1fr_auto_auto_auto_auto] gap-2 items-center">
+        <input
+          inputMode="decimal"
+          placeholder={unitLabel(unit)}
+          value={weight}
+          onChange={(e) => setWeight(e.target.value)}
+          className="h-10 rounded-lg px-3 border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900"
+          aria-label={`Weight in ${unitLabel(unit)}`}
+        />
+        <input
+          inputMode="numeric"
+          placeholder="reps"
+          value={reps}
+          onChange={(e) => setReps(e.target.value)}
+          className="h-10 rounded-lg px-3 border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900"
+          aria-label="Reps"
+        />
+        <input
+          inputMode="decimal"
+          placeholder="RPE"
+          value={rpe}
+          onChange={(e) => setRpe(e.target.value)}
+          className="h-10 rounded-lg px-3 border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900"
+          aria-label="RPE"
+        />
+
+        {/* Repeat last */}
+        <button
+          onClick={onRepeat}
+          title="Repeat last"
+          aria-label="Repeat last set"
+          className="h-10 w-10 rounded-lg border border-neutral-300 dark:border-neutral-700"
+        >
+          ↻
+        </button>
+
+        {/* Voice */}
+        <button
+          onClick={onVoice}
+          title="Voice input"
+          aria-label="Voice input"
+          className={`h-10 w-10 rounded-lg border ${listening ? "border-green-500" : "border-neutral-300 dark:border-neutral-700"}`}
+        >
+          🎤
+        </button>
+
+        {/* Plates */}
+        <button
+          onClick={() => setOpenPlates(true)}
+          title="Plate calculator"
+          aria-label="Plate calculator"
+          className="h-10 w-10 rounded-lg border border-neutral-300 dark:border-neutral-700"
+        >
+          🥞
+        </button>
+
+        {/* Save */}
+        <button
+          onClick={() => {
+            hapticTap();
+            const wVal = fromUserUnits(parseFloat(weight) || 0, unit);
+            const rVal = parseInt(reps) || undefined;
+            const rpeNum = parseFloat(rpe) || undefined;
+            completeSet(exId, setId, {
+              weight: isNaN(wVal) ? undefined : wVal,
+              reps: rVal,
+              rpe: rpeNum,
+            });
+          }}
+          className={`h-10 px-4 rounded-lg text-white dark:text-black ${prStatus.tone === "pr" ? "bg-green-700 dark:bg-green-400" : "bg-black dark:bg-white"}`}
+        >
+          ✓
+        </button>
+
+        <PlateModal
+          open={openPlates}
+          onClose={() => setOpenPlates(false)}
+          initialTarget={parseFloat(weight) || undefined}
+        />
+      </div>
+
+      {/* PR nudge line */}
+      {prStatus.tone !== "none" && (
+        <div
+          className={`text-xs rounded-md px-2 py-1 inline-block ${
+            prStatus.tone === "pr"
+              ? "bg-green-600/10 border border-green-600/30"
+              : "bg-amber-500/10 border border-amber-500/30"
+          }`}
+        >
+          {prStatus.text}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/Exercises.tsx
+++ b/src/pages/Exercises.tsx
@@ -3,12 +3,14 @@ import { useWorkoutStore } from "../store/workout";
 import { useDbExercises } from "../hooks/useDbExercises";
 import ExerciseInfoModal from "../components/ExerciseInfoModal";
 import { muscleMeta } from "../lib/muscle";
+import { isRecentPR, personalRecord, latestTimeForExercise } from "../utils/prs";
 
 export default function Exercises() {
   const ensure = useWorkoutStore((s) => s.ensureActive);
   const addExercise = useWorkoutStore((s) => s.addExercise);
   const favorites = useWorkoutStore((s) => s.favorites);
   const toggleFav = useWorkoutStore((s) => s.toggleFavoriteExercise);
+  const history = useWorkoutStore((s) => s.history);
 
   const { data, loading, error, fuse } = useDbExercises();
 
@@ -108,17 +110,19 @@ export default function Exercises() {
             <div key={e.id} className="rounded-2xl border border-neutral-200 dark:border-neutral-800 p-4">
               <div className="flex items-center justify-between gap-2 mb-1">
                 <div className="min-w-0">
-                  <div className="font-medium truncate">{e.name}</div>
-                  <div className="text-xs opacity-80 flex items-center gap-2">
-                    <span className="inline-flex items-center gap-1">
-                      <span
-                        className="inline-block h-2.5 w-2.5 rounded-full"
-                        style={{ backgroundColor: muscleMeta(e.primary).color }}
-                      />
-                      {e.primary}
-                    </span>
-                    • {e.equipment.join(", ") || "No equipment"}
+                  <div className="font-medium truncate flex items-center gap-2">
+                    <span className="truncate">{e.name}</span>
+                    {(() => {
+                      const pr = personalRecord(history, e.name);
+                      const latest = latestTimeForExercise(history, e.name);
+                      const recent = isRecentPR(history, e.name, 30);
+                      const showBadge = !!pr && !!latest && recent && pr!.t === latest;
+                      return showBadge ? (
+                        <span className="inline-flex items-center text-[11px] px-2 py-0.5 rounded-full bg-green-600 text-white">PR</span>
+                      ) : null;
+                    })()}
                   </div>
+                  <div className="text-xs opacity-80 truncate">{e.primary} • {e.equipment.join(", ") || "No equipment"}</div>
                 </div>
                 <div className="flex gap-2 shrink-0">
                   <button title="Info" onClick={() => { setSelected(e); setShow(true); }}

--- a/src/pages/Workouts.tsx
+++ b/src/pages/Workouts.tsx
@@ -51,7 +51,11 @@ export default function Workouts() {
                   ))}
                 </div>
                 <div className="mt-3">
-                  <button onClick={() => addSet(ex.id)} className="rounded-lg border px-4 h-10 border-neutral-300 dark:border-neutral-700">
+                  <button
+                    onClick={() => addSet(ex.id)}
+                    aria-label={`Add set to ${ex.name}`}
+                    className="rounded-lg border px-4 h-10 border-neutral-300 dark:border-neutral-700"
+                  >
                     Add set
                   </button>
                 </div>

--- a/src/utils/history.ts
+++ b/src/utils/history.ts
@@ -1,0 +1,39 @@
+import { Workout } from "../store/workout";
+
+export type SetLike = { weight?: number; reps?: number; rpe?: number };
+
+/** Scan a workout for the last completed set of a named exercise (weight+reps present). */
+export function lastCompletedSetInWorkoutForName(workout: Workout, exerciseName: string): SetLike | null {
+  const ex = workout.exercises.find((e) => e.name.toLowerCase() === exerciseName.toLowerCase());
+  if (!ex) return null;
+  for (let i = ex.sets.length - 1; i >= 0; i--) {
+    const s = ex.sets[i];
+    if (s.done && typeof s.weight === "number" && typeof s.reps === "number") {
+      return { weight: s.weight, reps: s.reps, rpe: s.rpe };
+    }
+  }
+  return null;
+}
+
+/** Scan the active workout by exercise id for the last completed set. */
+export function lastCompletedSetInActiveByExId(active: Workout | null, exId: string): SetLike | null {
+  if (!active) return null;
+  const ex = active.exercises.find((e) => e.id === exId);
+  if (!ex) return null;
+  for (let i = ex.sets.length - 1; i >= 0; i--) {
+    const s = ex.sets[i];
+    if (s.done && typeof s.weight === "number" && typeof s.reps === "number") {
+      return { weight: s.weight, reps: s.reps, rpe: s.rpe };
+    }
+  }
+  return null;
+}
+
+/** From history (most recent first), find last completed set of a named exercise. */
+export function lastCompletedSetInHistory(history: Workout[], exerciseName: string): SetLike | null {
+  for (const w of history) {
+    const found = lastCompletedSetInWorkoutForName(w, exerciseName);
+    if (found) return found;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add helpers to find last completed set in active workout or history
- show PR badge when latest exercise entry is all-time PR
- repeat last set, PR proximity nudges, and PR-pace styling in set rows
- add aria-label for add set button

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae24807b848325b0898d37a7c796c0