### PR TITLE
Fix exercise lookup import path

### DIFF
--- a/src/utils/exerciseLookup.ts
+++ b/src/utils/exerciseLookup.ts
@@ -1,8 +1,12 @@
-import { EXERCISES } from "../data/exercises";
+import EXERCISES from "../../data/exercises.json";
+
+type Exercise = { name: string; primary?: string; muscle?: string };
 
 export function primaryMuscleFor(name: string): string {
-  const found = EXERCISES.find((e) => e.name.toLowerCase() === name.toLowerCase());
-  return found?.primary ?? "Other";
+  const found = (EXERCISES as Exercise[]).find(
+    (e) => e.name.toLowerCase() === name.toLowerCase()
+  );
+  return found?.primary ?? found?.muscle ?? "Other";
 }
 
 export function est1RM(weight?: number, reps?: number): number | undefined {


### PR DESCRIPTION
## Summary
- fix missing exercises import in exerciseLookup utility
- handle both `primary` and `muscle` fields when determining primary muscle

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae34fda71883258691fa5cec9bdd2a