### PR TITLE
Replace @apply usage for body styles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,5 +5,13 @@
 /* Optional: align with our theme manager */
 :root { color-scheme: light dark; }
 html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
-body { @apply bg-neutral-50 text-neutral-900 dark:bg-neutral-950 dark:text-neutral-50; }
+body {
+  background-color: var(--color-neutral-50);
+  color: var(--color-neutral-900);
+}
+
+.dark body {
+  background-color: var(--color-neutral-950);
+  color: var(--color-neutral-50);
+}
 


### PR DESCRIPTION
## Summary
- avoid @apply bg-neutral-50 error by using Tailwind CSS variables for global body colors

## Testing
- `npm test`
- `npx vite build` *(fails: appWindow is not exported by @tauri-apps/api/window.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3ea1761883259acc48512bcf8e36