### PR TITLE
fix: ensure assets load in tauri builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ LiftTrackerAI/dist/
 node_modules/
 android
 src-tauri/target
+src-tauri/Cargo.lock

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,16 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "node:path";
 
+// Detect when building inside a Tauri environment so we can use a relative
+// base path. The absolute "/" base causes a blank screen in the packaged app
+// because asset URLs resolve to the filesystem root.
+const isTauri = !!process.env.TAURI_PLATFORM;
+
 export default defineConfig({
   plugins: [react()],
-  base: "/",
+  // Use a relative base in Tauri builds to correctly load assets. For the web
+  // dev server or browser builds we keep the default absolute base.
+  base: isTauri ? "./" : "/",
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"),


### PR DESCRIPTION
## Summary
- detect Tauri builds and use a relative base path so assets resolve correctly
- ignore `src-tauri/Cargo.lock`

## Testing
- `npm test`
- `TAURI_PLATFORM=linux npx vite build` *(fails: Cannot find package '@tailwindcss/postcss')*

------
https://chatgpt.com/codex/tasks/task_e_68ae4571f34c83259a29bdccf9a76134