### PR TITLE
use vite for web build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "build": "tsc",
+    "build": "vite build && tsc",
+    "build:web": "vite build",
     "start:coach": "node dist/LiftTrackerAI/server/index.js",
     "dev:coach": "tsx LiftTrackerAI/server/index.ts",
     "android:sync": "npx cap sync",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "build": {
-    "beforeBuildCommand": "npm run build",
+    "beforeBuildCommand": "npm run build:web",
     "beforeDevCommand": "npm run dev",
     "devPath": "http://localhost:5173",
     "distDir": "../dist"


### PR DESCRIPTION
## Summary
- run Vite during build and expose dedicated `build:web` script
- update Tauri config to invoke the Vite build script

## Testing
- `npm test`
- `npm run build:web` *(fails: "appWindow" is not exported by "@tauri-apps/api/window.js")*

------
https://chatgpt.com/codex/tasks/task_e_68ae476750188325b94ec33176754da4