### PR TITLE
Fix router base path for Tauri bundle

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -29,7 +29,7 @@ if (!rootEl) {
 ReactDOM.createRoot(rootEl).render(
   <React.StrictMode>
     <RootErrorBoundary>
-      <BrowserRouter>
+      <BrowserRouter basename={import.meta.env.BASE_URL}>
         <Routes>
           <Route path="/" element={<App />}>
             <Route index element={<Dashboard />} />


### PR DESCRIPTION
## Summary
- add `basename` to `BrowserRouter` so routes work when bundled with Tauri

## Testing
- `npm test`
- `npx --yes @tauri-apps/cli@1 build` *(fails: the package 'lift-legends' does not contain this feature: custom-protocol)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4768ecbc83258f7a84eb81af7f71