### PR TITLE
Check multiple Tauri env vars in Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,12 @@ import path from "node:path";
 // Detect when building inside a Tauri environment so we can use a relative
 // base path. The absolute "/" base causes a blank screen in the packaged app
 // because asset URLs resolve to the filesystem root.
-const isTauri = !!process.env.TAURI_PLATFORM;
+// Check for multiple Tauri-specific environment variables. Depending on the
+// build step, either TAURI_PLATFORM or TAURI_ARCH may be provided. If any of
+// them are present we assume a Tauri build and use a relative base path.
+const isTauri = Boolean(
+  process.env.TAURI_PLATFORM || process.env.TAURI_ARCH
+);
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- Detect Tauri build by checking `TAURI_PLATFORM` or `TAURI_ARCH` env vars and use a relative base path when either is present

## Testing
- `npm test`
- `TAURI_PLATFORM=linux npx vite build --outDir vite-out` *(fails: "appWindow" is not exported by "@tauri-apps/api/window")*
- `node -e "process.env.TAURI_PLATFORM='linux'; import('./vite.config.ts').then(m=>console.log('base', m.default.base))"`
- `node -e "delete process.env.TAURI_PLATFORM; delete process.env.TAURI_ARCH; import('./vite.config.ts').then(m=>console.log('base', m.default.base))"`


------
https://chatgpt.com/codex/tasks/task_e_68ae476a389c8325917f7de559590860