### PR TITLE
fix: update tauri window api

### DIFF
--- a/src/targets/tauri/Titlebar.tsx
+++ b/src/targets/tauri/Titlebar.tsx
@@ -1,4 +1,6 @@
-import { appWindow } from "@tauri-apps/api/window";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+const appWindow = getCurrentWindow();
 
 export default function Titlebar() {
   return (


### PR DESCRIPTION
## Summary
- use `getCurrentWindow` in Titlebar for Tauri v2 compatibility

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae496556708325a8c39b65df89b517