### PR TITLE
Fix sql.js and SVG type declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/node": "^24.3.0",
         "@types/react": "^19.1.11",
         "@types/react-dom": "^19.1.7",
+        "@types/sql.js": "^1.4.9",
         "@typescript-eslint/eslint-plugin": "^8.41.0",
         "@typescript-eslint/parser": "^8.41.0",
         "@vitejs/plugin-react": "^5.0.1",
@@ -1828,6 +1829,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.40.1.tgz",
+      "integrity": "sha512-sr53lnYkQNhjHNN0oJDdUm5564biioI5DuOpycufDVK7D3y+GR3oUswe2rlwY1nPNyusHbrJ9WoTyIHl4/Bpwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1962,6 +1970,17 @@
         "@types/http-errors": "*",
         "@types/node": "*",
         "@types/send": "*"
+      }
+    },
+    "node_modules/@types/sql.js": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.9.tgz",
+      "integrity": "sha512-ep8b36RKHlgWPqjNG9ToUrPiwkhwh0AEzy883mO5Xnd+cL6VBH1EvSjBAAuxLUFF2Vn/moE3Me6v9E1Lo+48GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/node": "^24.3.0",
     "@types/react": "^19.1.11",
     "@types/react-dom": "^19.1.7",
+    "@types/sql.js": "^1.4.9",
     "@typescript-eslint/eslint-plugin": "^8.41.0",
     "@typescript-eslint/parser": "^8.41.0",
     "@vitejs/plugin-react": "^5.0.1",

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module "*.svg" {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
## Summary
- add `@types/sql.js` for proper sql.js typings
- declare SVG module via `vite-env.d.ts` so TS resolves imported logos

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae5531cd9c8325a4b037f1bcba009f