### PR TITLE
Add error and 404 handling to Express server

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const path = require('path');
 
+require('dotenv').config();
+
 const app = express();
 const PORT = process.env.PORT || 5000;
 
@@ -11,6 +13,17 @@ app.use(express.static(path.join(__dirname, '../client')));
 // match an API route, send back React's index.html file.
 app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, '../client/index.html'));
+});
+
+// Catch-all 404 handler for unmatched routes
+app.use((req, res, next) => {
+  res.status(404).json({ error: 'Not Found' });
+});
+
+// Error-handling middleware
+app.use((err, req, res, next) => {
+  console.error(err.stack);
+  res.status(err.status || 500).json({ error: 'Internal Server Error' });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- load environment variables with `dotenv` and use `PORT` for server configuration
- add catch-all 404 middleware for unmatched routes
- add centralized error handler to log errors and return standardized JSON responses

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae77e64d8c83258533d05e5acb7bfe