### PR TITLE
chore(ci): add lint test build steps

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -22,8 +22,13 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
       - name: Install
         run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm test
       - name: Build
         run: npm run build
 


### PR DESCRIPTION
## Summary
- run lint, test, and build in CI
- cache npm dependencies with package-lock.json

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b601e1a0b0832590d679b11fdbb9ed