### PR TITLE
feat: add express server entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "start": "node server/index.js",
-    "server": "cd server && npm start",
-    "client": "vite",
-    "dev": "concurrently \"npm run server\" \"npm run client\"",
-    "build": "vite build && tsc",
+    "start": "node server/index.mjs",
+    "dev": "concurrently -n server,web -c auto \"node --watch server/index.mjs\" \"vite\"",
+    "build": "tsc -b && vite build",
     "build:web": "vite build",
     "start:coach": "node dist/LiftTrackerAI/server/index.js",
     "dev:coach": "tsx LiftTrackerAI/server/index.ts",
@@ -21,7 +19,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext .ts,.tsx --max-warnings 0",
     "format": "prettier --write .",
-    "check": "npm run format:check && npm run typecheck && npm run lint",
+    "check": "tsc -b && eslint . --ext .ts,.tsx --max-warnings=0",
     "codex:quick": "npm run check && npm run build",
     "codex:fmt": "npm run format && npm run lint",
     "format:check": "prettier --check ."

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -1,0 +1,33 @@
+import express from "express";
+import path from "path";
+import { fileURLToPath } from "url";
+import dotenv from "dotenv";
+
+dotenv.config();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+const PORT = process.env.PORT || 5000;
+
+// health
+app.get("/healthz", (_req, res) => res.status(200).json({ ok: true }));
+
+// static build
+app.use(express.static(path.join(__dirname, "../dist")));
+
+// fallback SPA
+app.get("*", (_req, res) => {
+  res.sendFile(path.join(__dirname, "../dist/index.html"));
+});
+
+// 404
+app.use((_req, res) => res.status(404).json({ error: "Not Found" }));
+
+// error handler
+app.use((err, _req, res, _next) => {
+  console.error(err);
+  res.status(500).json({ error: "Server Error" });
+});
+
+app.listen(PORT, () => console.log(`Server on :${PORT}`));

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,18 +1,23 @@
-import express from "express";
+import express, { Request, Response, NextFunction } from "express";
 import path from "path";
 import { fileURLToPath } from "url";
 import dotenv from "dotenv";
+
 dotenv.config();
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
 const app = express();
 const PORT = process.env.PORT || 5000;
 
 app.use(express.static(path.join(__dirname, "../dist")));
-app.get("*", (_req, res) => res.sendFile(path.join(__dirname, "../dist/index.html")));
 
-app.use((err: any, _req: any, res: any, _next: any) => {
+app.get("*", (_req: Request, res: Response) =>
+  res.sendFile(path.join(__dirname, "../dist/index.html"))
+);
+
+app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
   console.error(err);
   res.status(500).json({ error: "Internal Server Error" });
 });

--- a/src/branding/logo.ts
+++ b/src/branding/logo.ts
@@ -7,10 +7,12 @@ export const LOGO_DATA_URI =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5a7dEAAAAASUVORK5CYII="; // 1x1 transparent PNG
 
 export async function resolveLogoUrl(): Promise<string> {
-  try {
-    const candidate = "/branding/logo.png";
-    const res = await fetch(candidate, { method: "HEAD" });
-    if (res.ok) return candidate;
-  } catch {}
+    try {
+      const candidate = "/branding/logo.png";
+      const res = await fetch(candidate, { method: "HEAD" });
+      if (res.ok) return candidate;
+    } catch {
+      /* ignore */
+    }
   return LOGO_DATA_URI;
 }


### PR DESCRIPTION
## Summary
- add Express server index with health check, static serving, and SPA fallback
- run Vite and server concurrently; adjust build and check scripts
- resolve lint warnings in server and logo resolver

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7afe0634c8325959f47c95dac53db