### PR TITLE
feat: add theme provider and brand colors

### DIFF
--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,13 @@
+import { PropsWithChildren, useEffect } from "react";
+import { useTheme } from "../store/theme";
+
+export default function ThemeProvider({ children }: PropsWithChildren) {
+  const theme = useTheme((s) => s.theme);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+  }, [theme]);
+
+  return <>{children}</>;
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -10,3 +10,13 @@
     color: hsl(var(--foreground));
   }
 }
+
+:root[data-theme="brand"] {
+  --color-primary: theme(colors.brand.500);
+}
+:root[data-theme="legacy"] {
+  --color-primary: theme(colors.legacy.500);
+}
+.btn-primary {
+  @apply bg-[var(--color-primary)] text-white;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
-import ThemeProvider from "./providers/ThemeProvider";
+import ThemeProvider from "./components/ThemeProvider";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import { useWorkoutStore } from "../store/workout";
 import { uploadBackup, downloadBackup } from "../lib/sync";
-import { AppearanceSection } from "../features/settings/AppearanceSection";
+import SettingsAppearance from "../screens/SettingsAppearance";
 
 export default function Settings() {
   const settings = useWorkoutStore((s) => s.settings);
@@ -34,7 +34,7 @@ export default function Settings() {
     <div className="rounded-2xl border border-neutral-200 dark:border-neutral-800 p-4 space-y-6">
       <div className="text-lg font-semibold">Settings</div>
 
-      <AppearanceSection />
+      <SettingsAppearance />
 
       <div className="grid gap-3 sm:grid-cols-2">
         <label className="space-y-1">

--- a/src/screens/SettingsAppearance.tsx
+++ b/src/screens/SettingsAppearance.tsx
@@ -1,0 +1,22 @@
+import { useTheme } from "../store/theme";
+
+export default function SettingsAppearance() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <div className="p-4 space-y-3">
+      <h1 className="text-xl font-semibold">Appearance</h1>
+      <label className="flex items-center gap-2">
+        <span>Theme</span>
+        <select
+          className="select select-bordered"
+          value={theme}
+          onChange={(e) => setTheme(e.target.value as any)}
+        >
+          <option value="brand">Brand (new)</option>
+          <option value="legacy">Legacy</option>
+        </select>
+      </label>
+    </div>
+  );
+}
+

--- a/src/store/theme.ts
+++ b/src/store/theme.ts
@@ -1,0 +1,20 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type Theme = "brand" | "legacy";
+
+interface ThemeState {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+}
+
+export const useTheme = create<ThemeState>()(
+  persist(
+    (set) => ({
+      theme: "brand",
+      setTheme: (t) => set({ theme: t }),
+    }),
+    { name: "ll-theme" },
+  ),
+);
+

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1,26 +1,26 @@
-/* Default: Legend Gold (gamer/premium) */
+/* Default: Brand */
 :root,
-.theme-legend {
+[data-theme="brand"] {
   --background: 218 36% 6%; /* near-black navy */
   --foreground: 0 0% 98%;
   --card: 218 28% 10%;
   --border: 218 16% 18%;
-  --primary: 45 68% 52%; /* gold */
+  --primary: 42 100% 50%;
   --primary-foreground: 0 0% 10%;
   --muted: 218 20% 22%;
   --muted-foreground: 0 0% 80%;
-  --accent: 45 78% 56%; /* lighter gold */
+  --accent: 47 100% 60%;
 }
 
-/* Classic: your current dark + green vibe (kept as an option) */
-.theme-classic {
-  --background: 222 47% 11%; /* slate-900-ish */
+/* Legacy: original colors */
+[data-theme="legacy"] {
+  --background: 222 47% 11%;
   --foreground: 0 0% 98%;
   --card: 222 36% 13%;
   --border: 222 20% 20%;
-  --primary: 142 71% 45%; /* green-500 */
+  --primary: 222 89% 55%;
   --primary-foreground: 0 0% 10%;
   --muted: 222 20% 20%;
   --muted-foreground: 0 0% 80%;
-  --accent: 200 98% 50%; /* cyan accent if needed */
+  --accent: 200 98% 50%;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,16 @@ export default {
           foreground: "hsl(var(--primary-foreground))",
         },
         accent: "hsl(var(--accent))",
+        brand: {
+          50: "hsl(48 100% 97%)",
+          100: "hsl(47 100% 92%)",
+          500: "hsl(42 100% 50%)",
+          600: "hsl(40 96% 40%)",
+          900: "hsl(28 60% 12%)",
+        },
+        legacy: {
+          500: "hsl(222 89% 55%)",
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary
- add brand and legacy color palettes in Tailwind config
- persist theme setting with new Zustand store
- wire ThemeProvider and appearance settings screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7b19db7e08325a43a0e1d511efb7d