### PR TITLE
feat: add workout log store and logging screen

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -12,10 +12,10 @@
 }
 
   :root[data-theme="brand"] {
-    --color-primary: theme('colors.brand.500');
+    --color-primary: var(--color-brand-500);
   }
   :root[data-theme="legacy"] {
-    --color-primary: theme('colors.legacy.500');
+    --color-primary: var(--color-legacy-500);
   }
   .btn-primary {
     @apply bg-[var(--color-primary)] text-white;

--- a/src/screens/LogWorkout.tsx
+++ b/src/screens/LogWorkout.tsx
@@ -1,0 +1,80 @@
+import { useLog } from "../store/log";
+
+export default function LogWorkout() {
+  const { sets, add, remove, update } = useLog();
+
+  return (
+    <div className="p-4 space-y-3">
+      <h1 className="text-xl font-semibold">Log Workout</h1>
+      <form
+        className="flex gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          const f = new FormData(e.currentTarget as HTMLFormElement);
+          const rpeRaw = f.get("rpe");
+          add({
+            exerciseId: String(f.get("ex") ?? ""),
+            reps: Number(f.get("reps") ?? 0),
+            weight: Number(f.get("w") ?? 0),
+            rpe: rpeRaw ? Number(rpeRaw) : undefined,
+            note: String(f.get("note") ?? ""),
+          });
+          (e.currentTarget as HTMLFormElement).reset();
+        }}
+      >
+        <input name="ex" placeholder="exercise id" className="input input-bordered" />
+        <input
+          name="reps"
+          placeholder="reps"
+          type="number"
+          className="input input-bordered w-24"
+        />
+        <input
+          name="w"
+          placeholder="kg"
+          type="number"
+          className="input input-bordered w-24"
+        />
+        <input
+          name="rpe"
+          placeholder="RPE"
+          type="number"
+          step="0.5"
+          className="input input-bordered w-24"
+        />
+        <input name="note" placeholder="note" className="input input-bordered" />
+        <button className="btn btn-primary" type="submit">
+          Add
+        </button>
+      </form>
+      <ul className="space-y-2">
+        {sets.map((s) => (
+          <li
+            key={s.id}
+            className="border p-2 rounded-xl flex items-center justify-between"
+          >
+            <div>
+              #{s.exerciseId} — {s.reps}×{s.weight}kg {s.rpe ? `@RPE ${s.rpe}` : ""}
+            </div>
+            <div className="flex gap-2">
+              <button
+                className="btn"
+                onClick={() =>
+                  update(s.id, {
+                    note: prompt("Note?", s.note ?? "") ?? s.note,
+                  })
+                }
+              >
+                Note
+              </button>
+              <button className="btn" onClick={() => remove(s.id)}>
+                Delete
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/src/store/log.ts
+++ b/src/store/log.ts
@@ -1,0 +1,38 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type SetEntry = {
+  id: string;
+  exerciseId: string;
+  reps: number;
+  weight: number;
+  rpe?: number;
+  note?: string;
+  ts: number;
+};
+
+type State = {
+  sets: SetEntry[];
+  add: (s: Omit<SetEntry, "id" | "ts">) => void;
+  remove: (id: string) => void;
+  update: (id: string, p: Partial<SetEntry>) => void;
+};
+
+export const useLog = create<State>()(
+  persist(
+    (set, get) => ({
+      sets: [],
+      add: (s) =>
+        set({
+          sets: [...get().sets, { ...s, id: crypto.randomUUID(), ts: Date.now() }],
+        }),
+      remove: (id) => set({ sets: get().sets.filter((x) => x.id !== id) }),
+      update: (id, p) =>
+        set({
+          sets: get().sets.map((x) => (x.id === id ? { ...x, ...p } : x)),
+        }),
+    }),
+    { name: "ll-log" },
+  ),
+);
+


### PR DESCRIPTION
## Summary
- add zustand store for persisting logged sets
- add simple LogWorkout screen to add, update, and delete sets
- use CSS variables for theme colors to resolve tailwind build error

## Testing
- `npm run build:web`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7b7141d148325843a24dbc56c2e0e