### PR TITLE
feat: add coach API proxy and React hook

### DIFF
--- a/server/coach.mjs
+++ b/server/coach.mjs
@@ -1,0 +1,34 @@
+import express from "express";
+import fetch from "node-fetch";
+
+const router = express.Router();
+
+router.post("/", async (req, res) => {
+  try {
+    const key = process.env.GROQ_API_KEY;
+    if (!key) return res.status(500).json({ error: "Missing GROQ_API_KEY" });
+    const { messages, model } = req.body || {};
+    const r = await fetch(
+      "https://api.groq.com/openai/v1/chat/completions",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${key}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: model || process.env.GROQ_MODEL || "llama-3.1-70b-versatile",
+          messages,
+        }),
+      },
+    );
+    const j = await r.json();
+    res.json(j);
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: "coach failed" });
+  }
+});
+
+export default router;
+

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -2,6 +2,7 @@ import express from "express";
 import path from "path";
 import { fileURLToPath } from "url";
 import dotenv from "dotenv";
+import coach from "./coach.mjs";
 
 dotenv.config();
 const __filename = fileURLToPath(import.meta.url);
@@ -9,6 +10,9 @@ const __dirname = path.dirname(__filename);
 
 const app = express();
 const PORT = process.env.PORT || 5000;
+
+app.use(express.json({ limit: "1mb" }));
+app.use("/api/coach", coach);
 
 // health
 app.get("/healthz", (_req, res) => res.status(200).json({ ok: true }));

--- a/src/hooks/useCoach.ts
+++ b/src/hooks/useCoach.ts
@@ -1,0 +1,31 @@
+import { useState } from "react";
+
+type Msg = { role: "system" | "user" | "assistant"; content: string };
+
+export function useCoach() {
+  const [messages, setMessages] = useState<Msg[]>([
+    {
+      role: "system",
+      content: "You are Lift Legends AI Coach. Be concise and practical.",
+    },
+  ]);
+  const [loading, setLoading] = useState(false);
+
+  const ask = async (content: string) => {
+    const next = [...messages, { role: "user", content } as Msg];
+    setMessages(next);
+    setLoading(true);
+    const r = await fetch("/api/coach", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: next }),
+    });
+    const j = await r.json();
+    const reply = j?.choices?.[0]?.message?.content || "…";
+    setMessages([...next, { role: "assistant", content: reply }]);
+    setLoading(false);
+  };
+
+  return { messages, ask, loading };
+}
+


### PR DESCRIPTION
## Summary
- add Express router to proxy Groq chat completions API
- expose `/api/coach` on server and include JSON parsing
- provide `useCoach` React hook for querying the proxy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7b8c3a4b083259180663e2f86e9ce