### PR TITLE
chore: add CI workflow with typecheck and Vercel deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,23 @@
 name: CI
 on:
-  push:
-    branches: [ "**" ]
   pull_request:
-    branches: [ "**" ]
+  push:
+    branches: [main]
 jobs:
-  web:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: 20
       - run: npm ci
-      - run: npm run build --if-present
+      - run: npm run check
+      - run: npm test
+      - if: github.event_name == 'push'
+        uses: amondnet/vercel-action@v21
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: .

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext .ts,.tsx --max-warnings 0",
     "format": "prettier --write .",
-    "check": "tsc -b && eslint . --ext .ts,.tsx --max-warnings=0",
+    "check": "tsc -b && ESLINT_USE_FLAT_CONFIG=false eslint . --ext .ts,.tsx --max-warnings=0",
     "codex:quick": "npm run check && npm run build",
     "codex:fmt": "npm run format && npm run lint",
     "format:check": "prettier --check ."

--- a/tests/mobile/serve.test.ts
+++ b/tests/mobile/serve.test.ts
@@ -11,7 +11,7 @@ beforeAll(() => {
   if (!fs.existsSync(distPath)) {
     execSync("npm run build:web", { stdio: "inherit" });
   }
-});
+}, 60000);
 
 describe("Mobile app", () => {
   it("serves built web bundle", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,11 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- run typecheck and tests on PRs
- deploy main branch to Vercel after checks
- add tsconfig path mapping for `@/`
- fix serve test timeout

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7b9c700a0832594f0b953ac56ad81